### PR TITLE
Add auto-grow index file cap and document --max-files option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-api"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "futures-util",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cache"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-context"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-graph"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-index"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-local-ai"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "neuromesh-core",
  "parking_lot",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-mcp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "neuromesh-cache",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-memory"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-observability"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-parser"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "neuromesh-core",
  "neuromesh-index",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-provider"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "futures-util",
  "neuromesh-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-router"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "neuromesh-context",
  "neuromesh-core",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-task"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "neuromesh-core",
  "neuromesh-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 exclude = ["tests/fixtures/mini-axum"]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.80"
 authors = ["NeuroMesh Team <team@neuromesh.local>"]

--- a/README.md
+++ b/README.md
@@ -213,6 +213,17 @@ HTTP / SSE MCP (`GET /sse`, `POST /mcp`) rides on the **monitor** process. Chang
 
 VS Code / Cursor: Settings → `neuromesh.port` must match the running monitor. After `neuromesh port 9000`, restart `neuromesh monitor` and set the editor to 9000.
 
+### Index file cap
+
+Default is **auto**: every production source, then tests, up to 50,000 files. The old silent 6,000-file stop is gone for large `src/` trees.
+
+```bash
+neuromesh index --max-files auto     # persist auto (default)
+neuromesh index --max-files 20000    # persist a hard limit
+```
+
+Priority: `--max-files` → `NEUROMESH_MAX_FILES` (`auto` / `0` = auto) → `.neuromesh/config.json` → auto. See [cli.md](docs/cli.md#index-file-cap).
+
 ---
 
 ## Tools
@@ -265,6 +276,6 @@ Index snapshot from that eval run: **219 files · 1,323 nodes · 2,891 edges · 
 | [MCP](docs/mcp.md) · [CLI](docs/cli.md) | Tools and commands |
 | [Quality](docs/quality.md) | Gold, eval, numbers |
 | [Contributing](docs/contributing.md) | Come build a solver or a language |
-| [Changelog](docs/CHANGELOG.md) | 0.6.1 |
+| [Changelog](docs/CHANGELOG.md) | 0.6.2 |
 
 MIT · [LICENSE](LICENSE)

--- a/crates/neuromesh-api/src/server.rs
+++ b/crates/neuromesh-api/src/server.rs
@@ -50,6 +50,11 @@ impl HttpServer {
         }
     }
 
+    fn project_walker(state: &AppState, root: PathBuf, pid: ProjectId) -> ProjectWalker {
+        let max_files = state.config.read().max_files;
+        ProjectWalker::new(root, pid).with_optional_max_files(max_files)
+    }
+
     async fn handle_connection(mut stream: TcpStream, state: Arc<AppState>) -> Result<()> {
         let mut header_bytes = Vec::new();
         let mut buf = [0u8; 8192];
@@ -445,8 +450,11 @@ impl HttpServer {
                                                 .map(|n| n.to_string_lossy().into_owned())
                                                 .unwrap_or_default();
                                             project_names.push(p_name.clone());
-                                            let walker =
-                                                ProjectWalker::new(p, ProjectId::new(&p_name));
+                                            let walker = Self::project_walker(
+                                                &state,
+                                                p,
+                                                ProjectId::new(&p_name),
+                                            );
                                             if let Ok(scanned) = walker.scan() {
                                                 indexed_count += scanned.len();
                                                 for (file, content) in &scanned {
@@ -491,7 +499,8 @@ impl HttpServer {
 
                             let new_project_id = ProjectId::new(&project_name);
                             state.graph.clear(Some(new_project_id.clone()));
-                            let walker = ProjectWalker::new(target_path, new_project_id.clone());
+                            let walker =
+                                Self::project_walker(&state, target_path, new_project_id.clone());
                             let mut indexed_count = 0;
                             if let Ok(scanned) = walker.scan() {
                                 indexed_count = scanned.len();
@@ -589,7 +598,7 @@ impl HttpServer {
                             .unwrap_or_else(|| "project".to_string());
                         let new_pid = ProjectId::new(&fallback_name);
                         state.graph.clear(Some(new_pid.clone()));
-                        let walker = ProjectWalker::new(fallback_dir, new_pid);
+                        let walker = Self::project_walker(&state, fallback_dir, new_pid);
                         if let Ok(scanned) = walker.scan() {
                             for (file, content) in &scanned {
                                 let ast = CodeIntelligenceEngine::analyze(
@@ -627,7 +636,7 @@ impl HttpServer {
                 let current_ws = state.workspace_path.read().clone();
                 let project_id = state.graph.project_id();
                 state.graph.clear(Some(project_id.clone()));
-                let walker = ProjectWalker::new(current_ws, project_id.clone());
+                let walker = Self::project_walker(&state, current_ws, project_id.clone());
                 let scanned = walker.scan().unwrap_or_default();
 
                 for (file, content) in &scanned {

--- a/crates/neuromesh-cli/src/commands/doctor.rs
+++ b/crates/neuromesh-cli/src/commands/doctor.rs
@@ -3,7 +3,9 @@ use neuromesh_index::ProjectWalker;
 use std::env;
 use std::net::TcpListener;
 
-pub fn execute() -> Result<()> {
+use super::{configured_walker, print_file_cap, FileCapArg};
+
+pub fn execute(cap: FileCapArg) -> Result<()> {
     println!("\nNeuroMesh doctor");
     println!(
         "OS             : {} ({})",
@@ -19,6 +21,11 @@ pub fn execute() -> Result<()> {
         Err(_) => println!("Monitor port   : {addr} in use"),
     }
     println!("Change with    : neuromesh port <n>  |  --port <n>  |  NEUROMESH_PORT");
+    match cfg.max_files {
+        Some(n) => println!("Max files      : {n} (explicit)"),
+        None => println!("Max files      : auto (production sources, ceiling 50,000)"),
+    }
+    println!("Change with    : neuromesh index --max-files <n|auto>  |  NEUROMESH_MAX_FILES");
 
     let cwd = env::current_dir()?;
     let root = ProjectWalker::discover_workspace(&cwd);
@@ -29,16 +36,11 @@ pub fn execute() -> Result<()> {
     }
     println!("Safety         : ok");
 
-    let walker = ProjectWalker::new(root.clone(), neuromesh_core::ProjectId::new("doctor"));
+    let walker = configured_walker(root.clone(), neuromesh_core::ProjectId::new("doctor"), cap);
     match walker.scan_report() {
         Ok(report) => {
             println!("Scan           : {} source files", report.files.len());
-            if report.truncated {
-                println!(
-                    "Truncated      : hit {}-file cap; {} more files not indexed (test trees queued last)",
-                    report.file_cap, report.omitted_over_cap
-                );
-            }
+            print_file_cap(&report, "");
             if report.skipped_count() > 0 {
                 println!(
                     "Skipped        : {} files ({})",

--- a/crates/neuromesh-cli/src/commands/evaluate.rs
+++ b/crates/neuromesh-cli/src/commands/evaluate.rs
@@ -18,7 +18,11 @@ pub fn execute() -> Result<()> {
         .unwrap_or("project")
         .to_string();
     let project_id = ProjectId::new(&project_name);
-    let walker = ProjectWalker::new(current_dir.clone(), project_id.clone());
+    let walker = super::configured_walker(
+        current_dir.clone(),
+        project_id.clone(),
+        super::FileCapArg::Unspecified,
+    );
     let scanned = walker.scan()?;
     if scanned.is_empty() {
         println!(

--- a/crates/neuromesh-cli/src/commands/graph.rs
+++ b/crates/neuromesh-cli/src/commands/graph.rs
@@ -1,6 +1,7 @@
 use neuromesh_core::{ProjectId, Result};
 use neuromesh_graph::NeuralProjectGraph;
-use neuromesh_index::ProjectWalker;
+
+use super::{configured_walker, FileCapArg};
 
 pub fn execute() -> Result<()> {
     let current_dir = std::env::current_dir()?;
@@ -11,7 +12,11 @@ pub fn execute() -> Result<()> {
         .to_string();
 
     let project_id = ProjectId::new(&project_name);
-    let walker = ProjectWalker::new(current_dir.clone(), project_id.clone());
+    let walker = configured_walker(
+        current_dir.clone(),
+        project_id.clone(),
+        FileCapArg::Unspecified,
+    );
     let scanned = walker.scan().unwrap_or_default();
 
     let graph = NeuralProjectGraph::new(project_id);

--- a/crates/neuromesh-cli/src/commands/index.rs
+++ b/crates/neuromesh-cli/src/commands/index.rs
@@ -1,11 +1,12 @@
 use neuromesh_core::{ProjectId, Result};
 use neuromesh_graph::NeuralProjectGraph;
-use neuromesh_index::ProjectWalker;
 use neuromesh_memory::{MemoryDatabase, ProjectFact};
 use std::fs;
 use std::sync::Arc;
 
-pub fn execute() -> Result<(Arc<NeuralProjectGraph>, Arc<MemoryDatabase>)> {
+use super::{configured_walker, persist_file_cap, print_file_cap, FileCapArg};
+
+pub fn execute(cap: FileCapArg) -> Result<(Arc<NeuralProjectGraph>, Arc<MemoryDatabase>)> {
     let current_dir = std::env::current_dir()?;
     let project_name = current_dir
         .file_name()
@@ -13,18 +14,23 @@ pub fn execute() -> Result<(Arc<NeuralProjectGraph>, Arc<MemoryDatabase>)> {
         .unwrap_or("neuromesh-project")
         .to_string();
 
+    if let Some(path) = persist_file_cap(cap)? {
+        let label = match cap {
+            FileCapArg::Auto => "auto".to_string(),
+            FileCapArg::Limit(n) => n.to_string(),
+            FileCapArg::Unspecified => unreachable!(),
+        };
+        println!("Saved          : {} (max_files = {label})", path.display());
+    }
+
     let project_id = ProjectId::new(&project_name);
-    let walker = ProjectWalker::new(current_dir.clone(), project_id.clone());
+    let walker = configured_walker(current_dir.clone(), project_id.clone(), cap);
 
     println!("🔍 Indexing Project Workspace...");
     let report = walker.scan_report()?;
     let skipped_count = report.skipped_count();
     let skipped_summary = report.skipped_summary();
-    let truncated = report.truncated;
-    let omitted = report.omitted_over_cap;
-    let file_cap = report.file_cap;
-    let scanned_files = report.files;
-    let total_files = scanned_files.len();
+    let total_files = report.files.len();
 
     let graph = Arc::new(NeuralProjectGraph::new(project_id.clone()));
     let _ = graph.load_persisted(&current_dir);
@@ -41,7 +47,7 @@ pub fn execute() -> Result<(Arc<NeuralProjectGraph>, Arc<MemoryDatabase>)> {
     let mut has_svelte = false;
     let mut has_js = false;
 
-    for (file, _) in &scanned_files {
+    for (file, _) in &report.files {
         total_tokens += file.token_count;
         if matches!(
             file.language,
@@ -75,7 +81,7 @@ pub fn execute() -> Result<(Arc<NeuralProjectGraph>, Arc<MemoryDatabase>)> {
             has_kotlin = true;
         }
     }
-    graph.ingest_workspace(&scanned_files);
+    graph.ingest_workspace(&report.files);
     graph.save_persisted(&current_dir)?;
 
     if has_html {
@@ -142,13 +148,9 @@ pub fn execute() -> Result<(Arc<NeuralProjectGraph>, Arc<MemoryDatabase>)> {
     let stats = graph.stats();
     println!("✓ Indexing Complete");
     println!("  Indexed Files  : {}", total_files);
+    print_file_cap(&report, "  ");
     if skipped_count > 0 {
         println!("  Skipped        : {} ({})", skipped_count, skipped_summary);
-    }
-    if truncated {
-        println!(
-            "  Truncated      : hit {file_cap}-file cap; {omitted} more files not indexed (test trees queued last)"
-        );
     }
     println!("  Total Tokens   : {}", total_tokens);
     println!("  Graph Nodes    : {}", stats.total_nodes);

--- a/crates/neuromesh-cli/src/commands/mod.rs
+++ b/crates/neuromesh-cli/src/commands/mod.rs
@@ -13,7 +13,8 @@ pub mod port;
 pub mod start;
 pub mod status;
 
-use neuromesh_core::{parse_port, Result};
+use neuromesh_core::{parse_max_files, parse_port, Config, ProjectId, Result};
+use neuromesh_index::ProjectWalker;
 
 /// `--port 9000`, `-p 9000`, or `--port=9000` anywhere in argv.
 pub fn port_from_args(args: &[String]) -> Result<Option<u16>> {
@@ -31,9 +32,91 @@ pub fn port_from_args(args: &[String]) -> Result<Option<u16>> {
     Ok(None)
 }
 
+/// `--max-files` flag: omitted, `auto`, or a positive limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileCapArg {
+    Unspecified,
+    Auto,
+    Limit(usize),
+}
+
+/// `--max-files 20000`, `--max-files=20000`, or `--max-files auto`.
+pub fn max_files_from_args(args: &[String]) -> Result<FileCapArg> {
+    for (i, a) in args.iter().enumerate() {
+        if a == "--max-files" {
+            let raw = args.get(i + 1).ok_or_else(|| {
+                neuromesh_core::NeuroMeshError::Config(
+                    "--max-files needs a number or `auto`".into(),
+                )
+            })?;
+            return Ok(match parse_max_files(raw)? {
+                None => FileCapArg::Auto,
+                Some(n) => FileCapArg::Limit(n),
+            });
+        }
+        if let Some(raw) = a.strip_prefix("--max-files=") {
+            return Ok(match parse_max_files(raw)? {
+                None => FileCapArg::Auto,
+                Some(n) => FileCapArg::Limit(n),
+            });
+        }
+    }
+    Ok(FileCapArg::Unspecified)
+}
+
+pub fn configured_walker(
+    root: std::path::PathBuf,
+    pid: ProjectId,
+    cap: FileCapArg,
+) -> ProjectWalker {
+    let walker = ProjectWalker::new(root, pid);
+    match cap {
+        FileCapArg::Unspecified => walker.with_optional_max_files(Config::load().max_files),
+        FileCapArg::Auto => walker,
+        FileCapArg::Limit(n) => walker.with_max_files(n),
+    }
+}
+
+pub fn apply_file_cap(config: Config, cap: FileCapArg) -> Config {
+    match cap {
+        FileCapArg::Unspecified => config,
+        FileCapArg::Auto => config.with_max_files(None),
+        FileCapArg::Limit(n) => config.with_max_files(Some(n)),
+    }
+}
+
+pub fn persist_file_cap(cap: FileCapArg) -> Result<Option<std::path::PathBuf>> {
+    let max_files = match cap {
+        FileCapArg::Unspecified => return Ok(None),
+        FileCapArg::Auto => None,
+        FileCapArg::Limit(n) => Some(n),
+    };
+    let path = Config::from_files()
+        .with_max_files(max_files)
+        .save_local()?;
+    Ok(Some(path))
+}
+
+pub fn print_file_cap(report: &neuromesh_index::ScanReport, indent: &str) {
+    if report.auto_cap {
+        println!(
+            "{indent}File cap       : auto → {} (ceiling {})",
+            report.file_cap, report.hard_cap
+        );
+    } else {
+        println!("{indent}File cap       : {} (explicit)", report.file_cap);
+    }
+    if report.truncated {
+        println!(
+            "{indent}Truncated      : {} files omitted (test trees queued last)",
+            report.omitted_over_cap
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::port_from_args;
+    use super::{max_files_from_args, port_from_args, FileCapArg};
 
     fn args(parts: &[&str]) -> Vec<String> {
         parts.iter().map(|s| (*s).to_string()).collect()
@@ -56,5 +139,26 @@ mod tests {
         assert_eq!(port_from_args(&args(&["monitor"])).unwrap(), None);
         assert!(port_from_args(&args(&["monitor", "--port"])).is_err());
         assert!(port_from_args(&args(&["monitor", "--port", "0"])).is_err());
+    }
+
+    #[test]
+    fn parses_max_files_flags() {
+        assert_eq!(
+            max_files_from_args(&args(&["index", "--max-files", "20000"])).unwrap(),
+            FileCapArg::Limit(20000)
+        );
+        assert_eq!(
+            max_files_from_args(&args(&["index", "--max-files=auto"])).unwrap(),
+            FileCapArg::Auto
+        );
+        assert_eq!(
+            max_files_from_args(&args(&["index", "--max-files", "auto"])).unwrap(),
+            FileCapArg::Auto
+        );
+        assert_eq!(
+            max_files_from_args(&args(&["index"])).unwrap(),
+            FileCapArg::Unspecified
+        );
+        assert!(max_files_from_args(&args(&["index", "--max-files"])).is_err());
     }
 }

--- a/crates/neuromesh-cli/src/commands/monitor.rs
+++ b/crates/neuromesh-cli/src/commands/monitor.rs
@@ -1,13 +1,14 @@
 use neuromesh_api::{AppState, HttpServer};
 use neuromesh_core::{Config, ProjectId, Result};
 use neuromesh_graph::NeuralProjectGraph;
-use neuromesh_index::ProjectWalker;
 use neuromesh_memory::MemoryDatabase;
 use neuromesh_provider::ProviderFactory;
 use std::io::Write;
 use std::sync::Arc;
 
-pub async fn execute(port_override: Option<u16>) -> Result<()> {
+use super::{apply_file_cap, configured_walker, FileCapArg};
+
+pub async fn execute(port_override: Option<u16>, cap: FileCapArg) -> Result<()> {
     let current_dir = std::env::current_dir()?;
     println!("NeuroMesh monitor: starting in {}", current_dir.display());
     let _ = std::io::stdout().flush();
@@ -16,6 +17,7 @@ pub async fn execute(port_override: Option<u16>) -> Result<()> {
     if let Some(port) = port_override {
         config = config.with_port(port);
     }
+    config = apply_file_cap(config, cap);
 
     let project_name = current_dir
         .file_name()
@@ -45,11 +47,11 @@ pub async fn execute(port_override: Option<u16>) -> Result<()> {
     let bg_dir = current_dir.clone();
     let bg_pid = project_id.clone();
     tokio::task::spawn_blocking(move || {
-        if !ProjectWalker::is_safe_workspace(&bg_dir) {
+        if !neuromesh_index::ProjectWalker::is_safe_workspace(&bg_dir) {
             eprintln!("NeuroMesh monitor: refused to index an unsafe workspace root");
             return;
         }
-        let walker = ProjectWalker::new(bg_dir.clone(), bg_pid);
+        let walker = configured_walker(bg_dir.clone(), bg_pid, cap);
         match walker.scan() {
             Ok(scanned) => {
                 bg_graph.ingest_workspace(&scanned);

--- a/crates/neuromesh-cli/src/commands/optimize.rs
+++ b/crates/neuromesh-cli/src/commands/optimize.rs
@@ -2,10 +2,11 @@ use neuromesh_context::gold::packet_file_names;
 use neuromesh_context::{ContextActivator, ReversibleContextRegistry};
 use neuromesh_core::{OptimizationMode, ProjectId, Result};
 use neuromesh_graph::NeuralProjectGraph;
-use neuromesh_index::ProjectWalker;
 use neuromesh_task::TaskSignatureExtractor;
 use std::sync::Arc;
 use std::time::Instant;
+
+use super::{configured_walker, FileCapArg};
 
 pub fn execute(task_prompt: Option<String>) -> Result<()> {
     let prompt =
@@ -18,7 +19,11 @@ pub fn execute(task_prompt: Option<String>) -> Result<()> {
         .unwrap_or("project")
         .to_string();
     let project_id = ProjectId::new(&project_name);
-    let walker = ProjectWalker::new(current_dir.clone(), project_id.clone());
+    let walker = configured_walker(
+        current_dir.clone(),
+        project_id.clone(),
+        FileCapArg::Unspecified,
+    );
     let scanned = walker.scan().unwrap_or_default();
 
     let graph = NeuralProjectGraph::new(project_id);

--- a/crates/neuromesh-cli/src/commands/start.rs
+++ b/crates/neuromesh-cli/src/commands/start.rs
@@ -1,13 +1,14 @@
 use neuromesh_api::{AppState, HttpServer};
 use neuromesh_core::{Config, ProjectId, Result};
 use neuromesh_graph::NeuralProjectGraph;
-use neuromesh_index::ProjectWalker;
 use neuromesh_memory::MemoryDatabase;
 use neuromesh_provider::ProviderFactory;
 use std::io::Write;
 use std::sync::Arc;
 
-pub async fn execute(port_override: Option<u16>) -> Result<()> {
+use super::{apply_file_cap, configured_walker, FileCapArg};
+
+pub async fn execute(port_override: Option<u16>, cap: FileCapArg) -> Result<()> {
     let current_dir = std::env::current_dir()?;
     println!("NeuroMesh gateway: starting in {}", current_dir.display());
     let _ = std::io::stdout().flush();
@@ -16,6 +17,7 @@ pub async fn execute(port_override: Option<u16>) -> Result<()> {
     if let Some(port) = port_override {
         config = config.with_port(port);
     }
+    config = apply_file_cap(config, cap);
 
     let project_name = current_dir
         .file_name()
@@ -31,10 +33,10 @@ pub async fn execute(port_override: Option<u16>) -> Result<()> {
     let bg_dir = current_dir.clone();
     let bg_pid = project_id.clone();
     tokio::task::spawn_blocking(move || {
-        if !ProjectWalker::is_safe_workspace(&bg_dir) {
+        if !neuromesh_index::ProjectWalker::is_safe_workspace(&bg_dir) {
             return;
         }
-        let walker = ProjectWalker::new(bg_dir.clone(), bg_pid);
+        let walker = configured_walker(bg_dir.clone(), bg_pid, cap);
         if let Ok(scanned) = walker.scan() {
             bg_graph.ingest_workspace(&scanned);
             let _ = bg_graph.save_persisted(&bg_dir);

--- a/crates/neuromesh-cli/src/commands/status.rs
+++ b/crates/neuromesh-cli/src/commands/status.rs
@@ -1,7 +1,8 @@
 use neuromesh_core::{ProjectId, Result};
 use neuromesh_graph::NeuralProjectGraph;
-use neuromesh_index::ProjectWalker;
 use neuromesh_memory::MemoryDatabase;
+
+use super::{configured_walker, FileCapArg};
 
 pub fn execute() -> Result<()> {
     let current_dir = std::env::current_dir()?;
@@ -11,7 +12,11 @@ pub fn execute() -> Result<()> {
         .unwrap_or("project")
         .to_string();
     let project_id = ProjectId::new(&project_name);
-    let walker = ProjectWalker::new(current_dir.clone(), project_id.clone());
+    let walker = configured_walker(
+        current_dir.clone(),
+        project_id.clone(),
+        FileCapArg::Unspecified,
+    );
     let scanned = walker.scan().unwrap_or_default();
 
     let graph = NeuralProjectGraph::new(project_id.clone());

--- a/crates/neuromesh-cli/src/main.rs
+++ b/crates/neuromesh-cli/src/main.rs
@@ -42,7 +42,8 @@ fn main() -> Result<()> {
             return commands::memory::execute();
         }
         "doctor" => {
-            return commands::doctor::execute();
+            let cap = commands::max_files_from_args(&args)?;
+            return commands::doctor::execute(cap);
         }
         "models" => {
             return commands::models::execute();
@@ -76,15 +77,18 @@ fn main() -> Result<()> {
 async fn async_main(command: &str, args: &[String]) -> Result<()> {
     match command {
         "index" => {
-            let _ = commands::index::execute()?;
+            let cap = commands::max_files_from_args(args)?;
+            let _ = commands::index::execute(cap)?;
         }
         "start" => {
             let port = commands::port_from_args(args)?;
-            commands::start::execute(port).await?;
+            let cap = commands::max_files_from_args(args)?;
+            commands::start::execute(port, cap).await?;
         }
         "monitor" | "ui" | "dashboard" => {
             let port = commands::port_from_args(args)?;
-            commands::monitor::execute(port).await?;
+            let cap = commands::max_files_from_args(args)?;
+            commands::monitor::execute(port, cap).await?;
         }
         "optimize" => {
             let prompt = args.get(2).cloned();
@@ -138,12 +142,13 @@ async fn async_main(command: &str, args: &[String]) -> Result<()> {
             let bg_graph = graph.clone();
             let bg_dir = current_dir.clone();
             let bg_pid = project_id.clone();
+            let cap = commands::max_files_from_args(args)?;
             let _ = graph.load_persisted(&current_dir);
             tokio::task::spawn_blocking(move || {
                 if !neuromesh_index::ProjectWalker::is_safe_workspace(&bg_dir) {
                     return;
                 }
-                let walker = neuromesh_index::ProjectWalker::new(bg_dir.clone(), bg_pid);
+                let walker = commands::configured_walker(bg_dir.clone(), bg_pid, cap);
                 if let Ok(scanned) = walker.scan() {
                     bg_graph.ingest_workspace(&scanned);
                     let _ = bg_graph.save_persisted(&bg_dir);
@@ -192,5 +197,11 @@ fn print_help() {
     println!("  neuromesh mcp                   # what IDEs launch");
     println!("  neuromesh port 9000             # persist galaxy UI port");
     println!("  neuromesh monitor --port 9000   # one run only");
+    println!("  neuromesh index --max-files auto");
     println!("  neuromesh connect               # copy-paste MCP config\n");
+    println!("Index file cap:");
+    println!("  Default is auto: every production source, then tests, up to 50,000.");
+    println!("  neuromesh index --max-files 20000   persist a limit");
+    println!("  neuromesh index --max-files auto    persist auto (or --max-files=auto)");
+    println!("  NEUROMESH_MAX_FILES=20000           env override (auto / 0 = auto)");
 }

--- a/crates/neuromesh-core/src/config.rs
+++ b/crates/neuromesh-core/src/config.rs
@@ -112,6 +112,9 @@ pub struct Config {
     pub provider: ProviderConfig,
     pub local_ai: LocalAiConfig,
     pub thresholds: Thresholds,
+    /// Explicit index file cap. `None` (default) auto-grows to fit production sources.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_files: Option<usize>,
 }
 
 impl Default for Config {
@@ -127,6 +130,7 @@ impl Default for Config {
             provider: ProviderConfig::default(),
             local_ai: LocalAiConfig::default(),
             thresholds: Thresholds::default(),
+            max_files: None,
         }
     }
 }
@@ -135,7 +139,7 @@ impl Config {
     pub const DEFAULT_PORT: u16 = 8765;
 
     /// Project `.neuromesh/config.json`, then `~/.neuromesh/config.json`, then defaults.
-    /// `NEUROMESH_PORT` wins over files.
+    /// `NEUROMESH_PORT` and `NEUROMESH_MAX_FILES` win over files.
     pub fn load() -> Self {
         Self::from_files().with_env_overrides()
     }
@@ -170,6 +174,13 @@ impl Config {
                 self.port = port;
             }
         }
+        if let Ok(raw) = std::env::var("NEUROMESH_MAX_FILES") {
+            match parse_max_files(&raw) {
+                Ok(None) => self.max_files = None,
+                Ok(Some(n)) => self.max_files = Some(n),
+                Err(_) => {}
+            }
+        }
         self
     }
 
@@ -178,7 +189,12 @@ impl Config {
         self
     }
 
-    /// Write `port` / `host` into `<cwd>/.neuromesh/config.json`.
+    pub fn with_max_files(mut self, max_files: Option<usize>) -> Self {
+        self.max_files = max_files;
+        self
+    }
+
+    /// Write `port` / `host` / `max_files` into `<cwd>/.neuromesh/config.json`.
     /// Merges into the existing project file; never copies `~/.neuromesh` secrets.
     pub fn save_local(&self) -> Result<PathBuf> {
         let dir = std::env::current_dir()?.join(".neuromesh");
@@ -191,6 +207,7 @@ impl Config {
         };
         merged.port = self.port;
         merged.host = self.host.clone();
+        merged.max_files = self.max_files;
         fs::write(&path, serde_json::to_string_pretty(&merged)?)?;
         Ok(path)
     }
@@ -207,6 +224,21 @@ pub fn parse_port(raw: &str) -> Result<u16> {
     Ok(port)
 }
 
+/// `auto` / `0` = grow to production sources. Otherwise a positive file count.
+pub fn parse_max_files(raw: &str) -> Result<Option<usize>> {
+    let raw = raw.trim();
+    if raw.eq_ignore_ascii_case("auto") || raw == "0" {
+        return Ok(None);
+    }
+    let n: usize = raw
+        .parse()
+        .map_err(|_| NeuroMeshError::Config(format!("invalid --max-files: {raw}")))?;
+    if n == 0 {
+        return Ok(None);
+    }
+    Ok(Some(n))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,5 +253,13 @@ mod tests {
         assert!(parse_port("0").is_err());
         assert!(parse_port("abc").is_err());
         assert_eq!(parse_port("9000").unwrap(), 9000);
+    }
+
+    #[test]
+    fn parse_max_files_auto_and_limit() {
+        assert_eq!(parse_max_files("auto").unwrap(), None);
+        assert_eq!(parse_max_files("0").unwrap(), None);
+        assert_eq!(parse_max_files("20000").unwrap(), Some(20000));
+        assert!(parse_max_files("nope").is_err());
     }
 }

--- a/crates/neuromesh-core/src/lib.rs
+++ b/crates/neuromesh-core/src/lib.rs
@@ -5,7 +5,8 @@ pub mod token;
 pub mod types;
 
 pub use config::{
-    parse_port, Config, LocalAiConfig, OptimizationMode, ProviderConfig, ProviderType, Thresholds,
+    parse_max_files, parse_port, Config, LocalAiConfig, OptimizationMode, ProviderConfig,
+    ProviderType, Thresholds,
 };
 pub use error::{NeuroMeshError, Result};
 pub use task::{SubtaskNode, SubtaskStatus, TaskGraph, TaskIntent, TaskRisk, TaskSignature};

--- a/crates/neuromesh-index/src/walker.rs
+++ b/crates/neuromesh-index/src/walker.rs
@@ -16,6 +16,9 @@ pub struct ScanReport {
     pub truncated: bool,
     pub omitted_over_cap: usize,
     pub file_cap: usize,
+    /// True when the cap grew to fit production sources (not `--max-files`).
+    pub auto_cap: bool,
+    pub hard_cap: usize,
 }
 
 impl ScanReport {
@@ -39,22 +42,45 @@ pub struct ProjectWalker {
     root_path: PathBuf,
     project_id: ProjectId,
     max_file_size: u64,
-    max_files: usize,
+    /// `None` = auto: index every non-test source, then tests, up to `hard_cap`.
+    max_files: Option<usize>,
+    soft_cap: usize,
+    hard_cap: usize,
 }
 
 impl ProjectWalker {
+    pub const SOFT_CAP: usize = 6_000;
+    pub const HARD_CAP: usize = 50_000;
+
     pub fn new(root_path: PathBuf, project_id: ProjectId) -> Self {
         Self {
             root_path,
             project_id,
             max_file_size: 2 * 1024 * 1024, // 2MB max text file
-            max_files: 6_000,
+            max_files: None,
+            soft_cap: Self::SOFT_CAP,
+            hard_cap: Self::HARD_CAP,
+        }
+    }
+
+    pub fn with_max_files(mut self, max_files: usize) -> Self {
+        self.max_files = Some(max_files.max(1));
+        self
+    }
+
+    /// `None` keeps auto-grow. Used by CLI/MCP/API after reading config.
+    pub fn with_optional_max_files(self, max_files: Option<usize>) -> Self {
+        match max_files {
+            Some(n) => self.with_max_files(n),
+            None => self,
         }
     }
 
     #[cfg(test)]
-    pub fn with_max_files(mut self, max_files: usize) -> Self {
-        self.max_files = max_files;
+    fn with_auto_caps(mut self, soft: usize, hard: usize) -> Self {
+        self.max_files = None;
+        self.soft_cap = soft.max(1);
+        self.hard_cap = hard.max(self.soft_cap);
         self
     }
 
@@ -161,7 +187,8 @@ impl ProjectWalker {
 
     pub fn scan_report(&self) -> Result<ScanReport> {
         let mut report = ScanReport {
-            file_cap: self.max_files,
+            hard_cap: self.hard_cap,
+            auto_cap: self.max_files.is_none(),
             ..ScanReport::default()
         };
 
@@ -214,10 +241,20 @@ impl ProjectWalker {
                 .then_with(|| a.0.cmp(&b.0))
         });
 
-        if candidates.len() > self.max_files {
+        let production = candidates
+            .iter()
+            .filter(|(rel, _, _, _)| !is_test_like(rel))
+            .count();
+        let cap = match self.max_files {
+            Some(n) => n.clamp(1, self.hard_cap),
+            None => production.max(self.soft_cap).min(self.hard_cap),
+        };
+        report.file_cap = cap;
+
+        if candidates.len() > cap {
             report.truncated = true;
-            report.omitted_over_cap = candidates.len() - self.max_files;
-            candidates.truncate(self.max_files);
+            report.omitted_over_cap = candidates.len() - cap;
+            candidates.truncate(cap);
         }
 
         for (relative_path, full_path, byte_size, last_modified) in candidates {
@@ -243,7 +280,7 @@ impl ProjectWalker {
     }
 }
 
-/// Test trees are indexed, but after production sources so a 6k-file cap
+/// Test trees are indexed, but after production sources so a file cap
 /// does not drop `HttpKernel.php` in favor of `Tests/`.
 fn is_test_like(path: &Path) -> bool {
     path.components().any(|c| {
@@ -353,6 +390,7 @@ mod tests {
         let walker = ProjectWalker::new(root.clone(), neuromesh_core::ProjectId::new("cap"))
             .with_max_files(1);
         let report = walker.scan_report().unwrap();
+        assert!(!report.auto_cap);
         assert!(report.truncated);
         assert_eq!(report.omitted_over_cap, 2);
         assert_eq!(report.files.len(), 1);
@@ -366,6 +404,33 @@ mod tests {
             "cap must keep production sources, got {:?}",
             report.files[0].0.relative_path
         );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn auto_cap_grows_to_cover_production_sources() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("walk_cap_tmp")
+            .join(format!("nm-walk-auto-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("tests")).unwrap();
+        fs::write(root.join("src/A.php"), "<?php class A {}").unwrap();
+        fs::write(root.join("src/B.php"), "<?php class B {}").unwrap();
+        fs::write(root.join("src/C.php"), "<?php class C {}").unwrap();
+        fs::write(root.join("tests/z.php"), "<?php class Z {}").unwrap();
+        let walker = ProjectWalker::new(root.clone(), neuromesh_core::ProjectId::new("auto"))
+            .with_auto_caps(2, 10);
+        let report = walker.scan_report().unwrap();
+        assert!(report.auto_cap);
+        assert_eq!(report.file_cap, 3, "auto cap should match production count");
+        assert_eq!(report.files.len(), 3);
+        assert!(report.truncated);
+        assert_eq!(report.omitted_over_cap, 1);
+        assert!(report
+            .files
+            .iter()
+            .all(|(f, _)| !f.relative_path.to_string_lossy().contains("tests")));
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/crates/neuromesh-index/src/watcher.rs
+++ b/crates/neuromesh-index/src/watcher.rs
@@ -50,7 +50,8 @@ impl WorkspaceWatcher {
         let thread_running = running.clone();
 
         // Initial scan to populate known hashes
-        let walker = ProjectWalker::new(root.clone(), project_id.clone());
+        let walker = ProjectWalker::new(root.clone(), project_id.clone())
+            .with_optional_max_files(neuromesh_core::Config::load().max_files);
         if let Ok(initial_files) = walker.scan() {
             for (file, _) in initial_files {
                 self.known_hashes
@@ -69,7 +70,8 @@ impl WorkspaceWatcher {
                 if last_scan.elapsed() >= interval {
                     last_scan = Instant::now();
 
-                    let walker = ProjectWalker::new(root.clone(), project_id.clone());
+                    let walker = ProjectWalker::new(root.clone(), project_id.clone())
+                        .with_optional_max_files(neuromesh_core::Config::load().max_files);
                     if let Ok(current_files) = walker.scan() {
                         let mut current_map = HashMap::new();
 

--- a/crates/neuromesh-mcp/src/server.rs
+++ b/crates/neuromesh-mcp/src/server.rs
@@ -137,7 +137,10 @@ impl McpServer {
                             let _ = self.handler.graph().load_persisted(&p_buf);
                             tokio::task::spawn_blocking(move || {
                                 let walker =
-                                    neuromesh_index::ProjectWalker::new(bg_dir.clone(), bg_pid);
+                                    neuromesh_index::ProjectWalker::new(bg_dir.clone(), bg_pid)
+                                        .with_optional_max_files(
+                                            neuromesh_core::Config::load().max_files,
+                                        );
                                 if let Ok(scanned) = walker.scan() {
                                     bg_graph.ingest_workspace(&scanned);
                                     let _ = bg_graph.save_persisted(&bg_dir);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable user-facing changes live here. The README stays a product guide, not a version diary.
 
+## 0.6.2 — 2026-08-24
+
+Scale search on large repos, auto index cap, and `--max-files`.
+
+- **Scale search.** Exact class/interface names outrank fuzzy `Http`/`Kernel` tokens. `neuromesh_get_context` uses `coverage.claim = no_seed_resolved` when every identifier misses, and does not ship a utility fallback file.
+- **Index file cap.** Default is **auto**: grow to every production source (then tests), ceiling 50,000. `neuromesh index --max-files 20000` (or `auto`) persists like `neuromesh port`. Env `NEUROMESH_MAX_FILES`. `index` / `doctor` print the applied cap and warn on truncation.
+
 ## 0.6.1 — 2026-08-24
 
 Language registry, tree-sitter queries, framework overlays, parallel index, and thinner packets.
@@ -20,7 +27,6 @@ Language registry, tree-sitter queries, framework overlays, parallel index, and 
 - **Eval honesty.** `neuromesh eval` prints fixture dirs with an empty scan instead of skipping them. README numbers from release eval (2026-08-24): 219 files, 1,323 nodes, 2,891 edges, ~209 ms index.
 - **Monitor galaxy.** 2D clicks open nodes (they used to pan instead). 3D picking chooses the front-most blob, pauses spin on hover, and ignores giant label hit-boxes. Nodes render as Physarum slime; **Play slime** grows, streams, and prunes tubes.
 - **Monitor header.** Drop the extra Projects & Switch button — click the active-project chip to open the switcher. Compact one-line labels.
-- **Scale search.** Exact class/interface names outrank fuzzy `Http`/`Kernel` tokens. `neuromesh_get_context` uses `coverage.claim = no_seed_resolved` when every identifier misses, and does not ship a utility fallback file. Index queues `tests/` after production sources and prints when the 6,000-file cap truncates.
 
 ## 0.5.2 — 2026-08-23
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # HTTP monitor
 
-`neuromesh monitor` binds **http://127.0.0.1:8765** by default (local only). Change it with `neuromesh port 9000`, `neuromesh monitor --port 9000`, or `NEUROMESH_PORT`. See [cli.md](cli.md#monitor-port). Use this for the graph UI and for clients that speak HTTP/SSE instead of stdio MCP.
+`neuromesh monitor` binds **http://127.0.0.1:8765** by default (local only). Change it with `neuromesh port 9000`, `neuromesh monitor --port 9000`, or `NEUROMESH_PORT`. See [cli.md](cli.md#monitor-port). Re-index honors the same file cap as the CLI (`--max-files` / `NEUROMESH_MAX_FILES` / config; default auto, ceiling 50,000 — [cli.md](cli.md#index-file-cap)). Use this for the graph UI and for clients that speak HTTP/SSE instead of stdio MCP.
 
 ## UI
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ Evidence packet → MCP client
 1. **Structural honesty.** Import and call edges exist when the target resolves uniquely (same file, imported files, same crate, impl/field, or a single global definition). Several hits in one file are not a fake `Proven` edge. Failures stay `Likely` or unresolved — they are not dropped silently and they are not exploded into every namesake.
 2. **Bounded activation.** `get_context` seeds from the prompt and fills a neighborhood under a token cap. It does not score the entire graph on every request.
 3. **Reversible folds.** Untargeted function bodies become `[neuromesh:fold]` markers. The original text is registered; `neuromesh_expand_fold` returns it by `fold_id`.
-4. **Safe workspace.** Indexing walks up to a git, Cargo, or `package.json` root and refuses `$HOME` and drive roots.
+4. **Safe workspace.** Indexing walks up to a git, Cargo, or `package.json` root and refuses `$HOME` and drive roots. The file cap is **auto** (production sources first, tests last, ceiling 50,000) unless `--max-files` / `NEUROMESH_MAX_FILES` sets a limit.
 5. **Local.** MCP over stdio. No hosted service, no API key for indexing.
 
 ## Crates

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,3 +46,20 @@ Priority: `--port` / `-p` → env `NEUROMESH_PORT` → project `.neuromesh/confi
 `neuromesh start` honors the same flag. VS Code / Cursor setting `neuromesh.port` must match the process that is actually listening.
 
 `neuromesh mcp` does **not** bind a port (stdio only). Remote MCP is the monitor: `neuromesh monitor --port 9000`, then `http://127.0.0.1:9000/sse`.
+
+## Index file cap
+
+Default is **auto**. After a walk, production sources (`src/`, not `tests/` / `test/`) are indexed first. The cap grows to that production count (minimum 6,000) and never past **50,000**. Tests are queued last, so a Symfony-scale tree is not truncated in the middle of `src/`.
+
+```bash
+neuromesh index --max-files auto     # persist auto (default)
+neuromesh index --max-files 20000    # persist a hard limit
+neuromesh index --max-files=20000    # same
+neuromesh doctor --max-files 20000   # one scan only, does not save
+```
+
+`auto` and `0` mean auto-grow. Priority: `--max-files` → env `NEUROMESH_MAX_FILES` → project `.neuromesh/config.json` → `~/.neuromesh/config.json` → auto.
+
+`neuromesh index --max-files …` writes `max_files` next to the monitor port in `<cwd>/.neuromesh/config.json`, so `neuromesh mcp` / `monitor` pick it up. `neuromesh monitor --max-files 20000` is one run only (same idea as `--port`).
+
+`index` and `doctor` print `File cap: auto → N (ceiling 50000)` and `Truncated` when files were omitted. Re-index after changing the cap.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,6 @@
 # MCP tools
 
-Transport: **stdio JSON-RPC** (`neuromesh mcp`). That is what Cursor, Claude, Cline, and similar clients launch. Stdio has **no TCP port** — `--port` on `mcp` does nothing.
+Transport: **stdio JSON-RPC** (`neuromesh mcp`). That is what Cursor, Claude, Cline, and similar clients launch. Stdio has **no TCP port** — `--port` on `mcp` does nothing. Background index uses the same file-cap rules as `neuromesh index` (`--max-files`, `NEUROMESH_MAX_FILES`, `.neuromesh/config.json`; default auto, ceiling 50,000). See [cli.md](cli.md#index-file-cap).
 
 Remote / multi-agent: `neuromesh monitor` (optionally `--port 9000` / `neuromesh port 9000`), then SSE and HTTP as in [api.md](api.md).
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -45,6 +45,8 @@ From `neuromesh eval` (release, 2026-08-24) on this repository:
 | Edges | 2,891 |
 | Index time (release) | ~209 ms |
 
+Index file cap is **auto** by default (production sources first, tests last, ceiling 50,000). Override with `neuromesh index --max-files N`. See [cli.md](cli.md#index-file-cap).
+
 Fill caps: `max_savings` = 0 extra tokens, `balanced` = 5,000, `max_quality` = 16,000. Reduction is versus **this workspace**, not a fake 25k dump.
 
 Token savings from skeletonization are **per file and per task**. There is no universal 99% claim.

--- a/editors/vscode-neuromesh/README.md
+++ b/editors/vscode-neuromesh/README.md
@@ -2,7 +2,7 @@
 
 Sidebar mesh stats, a packet inspector, fold CodeLens, and the galaxy UI — talking to a running `neuromesh monitor`.
 
-The agent loop in the editor matches 0.6.1: **get_context → expand_fold**. Grep (`search_symbols`) only when coverage is `partial`. After a good edit, **record_feedback**.
+The agent loop in the editor matches 0.6.2: **get_context → expand_fold**. Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**.
 
 ## Install
 

--- a/editors/vscode-neuromesh/package.json
+++ b/editors/vscode-neuromesh/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-neuromesh",
   "displayName": "NeuroMesh",
   "description": "Evidence packets, reversible folds, and a live mesh sidebar for Cursor & VS Code. Don’t dump files — fold them.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publisher": "neuromesh",
   "license": "MIT",
   "homepage": "https://github.com/pinoox/neuromesh",


### PR DESCRIPTION
Scale search on large repos, auto index cap, and `--max-files`.

- **Scale search.** Exact class/interface names outrank fuzzy `Http`/`Kernel` tokens. `neuromesh_get_context` uses `coverage.claim = no_seed_resolved` when every identifier misses, and does not ship a utility fallback file.
- **Index file cap.** Default is **auto**: grow to every production source (then tests), ceiling 50,000. `neuromesh index --max-files 20000` (or `auto`) persists like `neuromesh port`. Env `NEUROMESH_MAX_FILES`. `index` / `doctor` print the applied cap and warn on truncation.