### PR TITLE
fix: extract PHP rethrow and ternary throw types for inbound trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-api"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "futures-util",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cache"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-context"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-graph"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-index"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-local-ai"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "neuromesh-core",
  "parking_lot",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-mcp"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "neuromesh-cache",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-memory"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-observability"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-parser"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "neuromesh-core",
  "neuromesh-index",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-provider"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "futures-util",
  "neuromesh-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-router"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "neuromesh-context",
  "neuromesh-core",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-task"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "neuromesh-core",
  "neuromesh-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 exclude = ["tests/fixtures/mini-axum"]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 rust-version = "1.80"
 authors = ["NeuroMesh Team <team@neuromesh.local>"]

--- a/README.md
+++ b/README.md
@@ -276,6 +276,6 @@ Index snapshot from that eval run: **219 files · 1,323 nodes · 2,891 edges · 
 | [MCP](docs/mcp.md) · [CLI](docs/cli.md) | Tools and commands |
 | [Quality](docs/quality.md) | Gold, eval, numbers |
 | [Contributing](docs/contributing.md) | Come build a solver or a language |
-| [Changelog](docs/CHANGELOG.md) | 0.6.2 |
+| [Changelog](docs/CHANGELOG.md) | 0.6.3 |
 
 MIT · [LICENSE](LICENSE)

--- a/crates/neuromesh-graph/src/quality_tests.rs
+++ b/crates/neuromesh-graph/src/quality_tests.rs
@@ -622,6 +622,101 @@ final class InstallPlatformCommand
     }
 
     #[test]
+    fn php_matcher_rethrow_is_inbound_to_resource_not_route() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("routing"));
+        let route_ex = "<?php\nclass RouteNotFoundException extends \\RuntimeException {}\n";
+        let resource_ex = "<?php\nclass ResourceNotFoundException extends \\RuntimeException {}\n";
+        let method_ex = "<?php\nclass MethodNotAllowedException extends \\RuntimeException {}\n";
+        let generator = r#"
+<?php
+class UrlGenerator {
+    public function generate(string $name): string {
+        throw new RouteNotFoundException('missing');
+    }
+}
+"#;
+        let matcher = r#"
+<?php
+class RedirectableUrlMatcher {
+    public function match(string $pathinfo): array {
+        try {
+            return parent::match($pathinfo);
+        } catch (ResourceNotFoundException $e) {
+            throw $e;
+        }
+    }
+}
+"#;
+        let dumper = r#"
+<?php
+class CompiledUrlMatcherDumper {
+    public function dump(): string {
+        throw 0 < $this->allow
+            ? new MethodNotAllowedException()
+            : new ResourceNotFoundException('no routes');
+    }
+}
+"#;
+        for (path, src) in [
+            ("src/RouteNotFoundException.php", route_ex),
+            ("src/ResourceNotFoundException.php", resource_ex),
+            ("src/MethodNotAllowedException.php", method_ex),
+            ("src/UrlGenerator.php", generator),
+            ("src/RedirectableUrlMatcher.php", matcher),
+            ("src/CompiledUrlMatcherDumper.php", dumper),
+        ] {
+            graph.ingest_file(
+                &indexed(path),
+                &CodeIntelligenceEngine::analyze(&PathBuf::from(path), src, SourceLanguage::PHP),
+                Some(src),
+            );
+        }
+        graph.finalize_links();
+
+        let route_in =
+            graph.trace_symbol("RouteNotFoundException", crate::TraceDirection::Inbound, 3);
+        let route_files: Vec<_> = route_in
+            .callers
+            .iter()
+            .map(|h| h.file_path.to_string_lossy().replace('\\', "/"))
+            .collect();
+        assert!(
+            route_files.iter().any(|p| p.ends_with("UrlGenerator.php")),
+            "generator throw site missing, callers {route_files:?}"
+        );
+        assert!(
+            !route_files
+                .iter()
+                .any(|p| p.contains("RedirectableUrlMatcher")
+                    || p.contains("CompiledUrlMatcherDumper")),
+            "matcher files must not be inbound to RouteNotFoundException, got {route_files:?}"
+        );
+
+        let resource_in = graph.trace_symbol(
+            "ResourceNotFoundException",
+            crate::TraceDirection::Inbound,
+            3,
+        );
+        let resource_files: Vec<_> = resource_in
+            .callers
+            .iter()
+            .map(|h| h.file_path.to_string_lossy().replace('\\', "/"))
+            .collect();
+        assert!(
+            resource_files
+                .iter()
+                .any(|p| p.ends_with("RedirectableUrlMatcher.php")),
+            "rethrow site missing, callers {resource_files:?}"
+        );
+        assert!(
+            resource_files
+                .iter()
+                .any(|p| p.ends_with("CompiledUrlMatcherDumper.php")),
+            "ternary throw site missing, callers {resource_files:?}"
+        );
+    }
+
+    #[test]
     fn kotlin_unique_save_does_not_explode_or_cross_link() {
         let graph = NeuralProjectGraph::new(ProjectId::new("android"));
         let store = r#"

--- a/crates/neuromesh-parser/src/calls.rs
+++ b/crates/neuromesh-parser/src/calls.rs
@@ -1,6 +1,7 @@
 use crate::types::{AstAnalysisResult, ParsedRelationship};
 use neuromesh_core::EdgeType;
 use regex::Regex;
+use std::collections::HashMap;
 use std::sync::OnceLock;
 
 const CALL_STOPWORDS: &[&str] = &[
@@ -192,27 +193,25 @@ pub fn extract_calls_from_line_ctx(
     }
 }
 
-/// `throw new X`, `catch (X`, and PHP `X $param` type hints — inbound to the type.
+/// Scan a whole function body so `throw $e` can see the matching `catch`.
+pub fn extract_type_uses_from_body(caller: &str, body: &str, result: &mut AstAnalysisResult) {
+    let mut catch_vars: HashMap<String, Vec<String>> = HashMap::new();
+    for line in body.lines() {
+        collect_catch_bindings(strip_line_comment(line), &mut catch_vars);
+    }
+    for line in body.lines() {
+        extract_type_uses_from_line(caller, line, result);
+        record_typed_rethrows(caller, strip_line_comment(line), &catch_vars, result);
+    }
+}
+
+/// `throw new X`, `catch (X`, ternary `throw … new X`, and PHP `X $param` hints.
 pub fn extract_type_uses_from_line(caller: &str, line: &str, result: &mut AstAnalysisResult) {
     let trimmed = strip_line_comment(line);
 
-    static CATCH_RE: OnceLock<Regex> = OnceLock::new();
-    let catch_re = CATCH_RE
-        .get_or_init(|| Regex::new(r"\bcatch\s*\(\s*\\?([A-Za-z_][A-Za-z0-9_\\]*)").unwrap());
-    for cap in catch_re.captures_iter(trimmed) {
-        if let Some(raw) = cap.get(1) {
-            record_type_use(caller, raw.as_str(), result);
-        }
-    }
-
-    static KT_CATCH_RE: OnceLock<Regex> = OnceLock::new();
-    let kt_catch_re = KT_CATCH_RE.get_or_init(|| {
-        Regex::new(r"\bcatch\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*:\s*([A-Za-z_][A-Za-z0-9_.]*)")
-            .unwrap()
-    });
-    for cap in kt_catch_re.captures_iter(trimmed) {
-        if let Some(raw) = cap.get(1) {
-            record_type_use(caller, raw.as_str(), result);
+    for (types, _) in catch_clauses(trimmed) {
+        for ty in types {
+            record_type_use(caller, &ty, result);
         }
     }
 
@@ -229,12 +228,125 @@ pub fn extract_type_uses_from_line(caller: &str, line: &str, result: &mut AstAna
         }
     }
 
+    if trimmed.contains("throw") {
+        static NEW_RE: OnceLock<Regex> = OnceLock::new();
+        let new_re =
+            NEW_RE.get_or_init(|| Regex::new(r"\bnew\s+\\?([A-Za-z_][A-Za-z0-9_\\]*)").unwrap());
+        for cap in new_re.captures_iter(trimmed) {
+            if let Some(raw) = cap.get(1) {
+                record_type_use(caller, raw.as_str(), result);
+            }
+        }
+    }
+
     static HINT_RE: OnceLock<Regex> = OnceLock::new();
     let hint_re =
         HINT_RE.get_or_init(|| Regex::new(r"\\?([A-Z][A-Za-z0-9_\\]*)\s+\$[A-Za-z_]").unwrap());
     for cap in hint_re.captures_iter(trimmed) {
         if let Some(raw) = cap.get(1) {
             record_type_use(caller, raw.as_str(), result);
+        }
+    }
+}
+
+fn catch_clauses(line: &str) -> Vec<(Vec<String>, Option<String>)> {
+    static CATCH_PAREN: OnceLock<Regex> = OnceLock::new();
+    let catch_paren = CATCH_PAREN.get_or_init(|| Regex::new(r"\bcatch\s*\(\s*([^)]*)\)").unwrap());
+    catch_paren
+        .captures_iter(line)
+        .filter_map(|cap| cap.get(1).map(|m| parse_catch_clause(m.as_str())))
+        .collect()
+}
+
+fn parse_catch_clause(inner: &str) -> (Vec<String>, Option<String>) {
+    let inner = inner.trim();
+    if inner.is_empty() {
+        return (Vec::new(), None);
+    }
+    if let Some((var, ty)) = inner.split_once(':') {
+        let var = var.trim();
+        if !var.is_empty()
+            && var.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            && !var.contains('$')
+        {
+            return (
+                vec![type_basename(ty.trim()).to_string()],
+                Some(var.to_string()),
+            );
+        }
+    }
+
+    let (types_part, php_var) = if let Some((types, var)) = inner.rsplit_once('$') {
+        (
+            types,
+            Some(var.split_whitespace().next().unwrap_or(var).to_string()),
+        )
+    } else {
+        (inner, None)
+    };
+
+    let mut types = Vec::new();
+    let mut java_var = None;
+    for piece in types_part.split('|') {
+        let piece = piece.trim().trim_start_matches('\\');
+        if piece.is_empty() {
+            continue;
+        }
+        let toks: Vec<&str> = piece.split_whitespace().collect();
+        if toks.len() >= 2 {
+            let last = toks[toks.len() - 1];
+            if last.chars().next().is_some_and(|c| c.is_lowercase()) {
+                java_var = Some(last.to_string());
+                types.push(type_basename(toks[0]).to_string());
+                continue;
+            }
+        }
+        types.push(type_basename(piece).to_string());
+    }
+    (types, php_var.or(java_var))
+}
+
+fn collect_catch_bindings(line: &str, catch_vars: &mut HashMap<String, Vec<String>>) {
+    for (types, var) in catch_clauses(line) {
+        if let Some(var) = var {
+            catch_vars.entry(var).or_default().extend(types);
+        }
+    }
+}
+
+fn record_typed_rethrows(
+    caller: &str,
+    line: &str,
+    catch_vars: &HashMap<String, Vec<String>>,
+    result: &mut AstAnalysisResult,
+) {
+    static PHP_VAR: OnceLock<Regex> = OnceLock::new();
+    let php_var =
+        PHP_VAR.get_or_init(|| Regex::new(r"\bthrow\s+\$([A-Za-z_][A-Za-z0-9_]*)").unwrap());
+    for cap in php_var.captures_iter(line) {
+        if let Some(var) = cap.get(1) {
+            if let Some(types) = catch_vars.get(var.as_str()) {
+                for ty in types {
+                    record_type_use(caller, ty, result);
+                }
+            }
+        }
+    }
+
+    static BARE_VAR: OnceLock<Regex> = OnceLock::new();
+    let bare_var =
+        BARE_VAR.get_or_init(|| Regex::new(r"\bthrow\s+([a-z_][A-Za-z0-9_]*)\b").unwrap());
+    for cap in bare_var.captures_iter(line) {
+        if let Some(var) = cap.get(1) {
+            let name = var.as_str();
+            if name == "new" {
+                continue;
+            }
+            if let Some(types) = catch_vars.get(name) {
+                for ty in types {
+                    record_type_use(caller, ty, result);
+                }
+            }
         }
     }
 }

--- a/crates/neuromesh-parser/src/generic.rs
+++ b/crates/neuromesh-parser/src/generic.rs
@@ -1,4 +1,4 @@
-use crate::calls::{brace_delta, extract_calls_from_line, extract_type_uses_from_line};
+use crate::calls::{brace_delta, extract_calls_from_line, extract_type_uses_from_body};
 use crate::types::{AstAnalysisResult, ParsedImport, ParsedRelationship, ParsedSymbol};
 use neuromesh_core::{EdgeType, NodeType};
 use regex::Regex;
@@ -58,6 +58,7 @@ impl GenericParser {
         let mut class_start_depth = 0i32;
         let mut depth = 0i32;
         let mut fn_line_start = 0usize;
+        let mut fn_body: Vec<String> = Vec::new();
 
         for (line_idx, line) in content.lines().enumerate() {
             let line_no = line_idx + 1;
@@ -110,11 +111,14 @@ impl GenericParser {
                 ruby_fn_re,
             ) {
                 if let Some(prev) = current_fn.take() {
+                    extract_type_uses_from_body(&prev, &fn_body.join("\n"), &mut result);
+                    fn_body.clear();
                     close_function(&mut result, &prev, fn_line_start, line_no);
                 }
                 current_fn = Some(fn_name.clone());
                 fn_start_depth = depth;
                 fn_line_start = line_no;
+                fn_body = vec![line.to_string()];
                 let exported = !line.contains("private") && !line.contains("protected");
                 result.symbols.push(ParsedSymbol {
                     name: fn_name.clone(),
@@ -127,16 +131,17 @@ impl GenericParser {
                     calls: Vec::new(),
                 });
                 extract_calls_from_line(&fn_name, line, &mut result);
-                extract_type_uses_from_line(&fn_name, line, &mut result);
             } else if let Some(caller) = current_fn.as_deref() {
+                fn_body.push(line.to_string());
                 extract_calls_from_line(caller, line, &mut result);
-                extract_type_uses_from_line(caller, line, &mut result);
             }
 
             depth += brace_delta(line);
 
             if current_fn.is_some() && depth <= fn_start_depth && line.contains('}') {
                 if let Some(prev) = current_fn.take() {
+                    extract_type_uses_from_body(&prev, &fn_body.join("\n"), &mut result);
+                    fn_body.clear();
                     close_function(&mut result, &prev, fn_line_start, line_no);
                 }
             }
@@ -146,6 +151,7 @@ impl GenericParser {
         }
 
         if let Some(prev) = current_fn.take() {
+            extract_type_uses_from_body(&prev, &fn_body.join("\n"), &mut result);
             close_function(
                 &mut result,
                 &prev,
@@ -355,6 +361,51 @@ final class InstallPlatformCommand
                 && r.source_symbol == "execute"
                 && r.target_symbol == "load"
         }));
+    }
+
+    #[test]
+    fn php_rethrow_and_ternary_new_become_calls() {
+        let matcher = r#"
+<?php
+class RedirectableUrlMatcher
+{
+    public function match(string $pathinfo): array
+    {
+        try {
+            return parent::match($pathinfo);
+        } catch (ResourceNotFoundException $e) {
+            if ($pathinfo === '/') {
+                throw $e;
+            }
+            throw 0 < count($this->allow)
+                ? new MethodNotAllowedException()
+                : new ResourceNotFoundException('no routes');
+        }
+    }
+}
+"#;
+        let ast = GenericParser::parse(&PathBuf::from("RedirectableUrlMatcher.php"), matcher);
+        for expected in ["ResourceNotFoundException", "MethodNotAllowedException"] {
+            assert!(
+                ast.relationships.iter().any(|r| {
+                    r.relationship == EdgeType::Calls
+                        && r.source_symbol == "match"
+                        && r.target_symbol == expected
+                }),
+                "missing inbound {expected}, got {:?}",
+                ast.relationships
+                    .iter()
+                    .filter(|r| r.source_symbol == "match")
+                    .map(|r| &r.target_symbol)
+                    .collect::<Vec<_>>()
+            );
+        }
+        assert!(
+            !ast.relationships.iter().any(|r| {
+                r.source_symbol == "match" && r.target_symbol == "RouteNotFoundException"
+            }),
+            "matcher must not be linked to RouteNotFoundException"
+        );
     }
 
     #[test]

--- a/crates/neuromesh-parser/src/query_extract.rs
+++ b/crates/neuromesh-parser/src/query_extract.rs
@@ -1,4 +1,4 @@
-use crate::calls::{extract_type_uses_from_line, is_callable_name};
+use crate::calls::{extract_type_uses_from_body, is_callable_name};
 use crate::imports::{
     expand_rust_use, last_import_segment, normalize_module_hint, record_import, split_import_alias,
 };
@@ -453,10 +453,7 @@ fn extract(
 
     if options.scan_type_uses {
         for func in &functions {
-            let body = text(func.node, src);
-            for line in body.lines() {
-                extract_type_uses_from_line(&func.name, line, &mut result);
-            }
+            extract_type_uses_from_body(&func.name, &text(func.node, src), &mut result);
         }
     }
 
@@ -1258,6 +1255,44 @@ func (s *Store) persist(body string) {}
         let save = php.symbols.iter().find(|s| s.name == "save").expect("save");
         assert_eq!(save.parent.as_deref(), Some("Store"));
         assert!(save.calls.iter().any(|c| c == "persist"));
+    }
+
+    #[test]
+    fn php_throw_rethrow_and_ternary_new_are_inbound() {
+        let php = parse_lang(
+            Grammar::Php,
+            PHP_QUERIES,
+            QueryOptions::php(),
+            "Matcher.php",
+            r#"<?php
+class RedirectableUrlMatcher {
+    public function match(string $pathinfo): array {
+        try {
+            return parent::match($pathinfo);
+        } catch (ResourceNotFoundException $e) {
+            if ($pathinfo === '/') {
+                throw $e;
+            }
+            throw 0 < count($this->allow)
+                ? new MethodNotAllowedException()
+                : new ResourceNotFoundException('no routes');
+        }
+    }
+}
+"#,
+        );
+        for expected in ["ResourceNotFoundException", "MethodNotAllowedException"] {
+            assert!(
+                php.relationships
+                    .iter()
+                    .any(|r| { r.source_symbol == "match" && r.target_symbol == expected }),
+                "php query extract missing {expected}: {:?}",
+                php.relationships
+                    .iter()
+                    .map(|r| format!("{}→{}", r.source_symbol, r.target_symbol))
+                    .collect::<Vec<_>>()
+            );
+        }
     }
 
     #[test]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable user-facing changes live here. The README stays a product guide, not a version diary.
 
+## 0.6.3 — 2026-08-25
+
+Inbound throw edges for PHP rethrow and ternary `new Type`.
+
+- **Inbound throws.** `throw $e` after `catch (Type $e)`, catch unions, and ternary `throw … new Type` become inbound `Calls` edges. Symfony matchers throw `ResourceNotFoundException`, not `RouteNotFoundException` — trace the type that is actually constructed or caught.
+
 ## 0.6.2 — 2026-08-24
 
 Scale search on large repos, auto index cap, and `--max-files`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -24,7 +24,7 @@ Start with `get_context`. `next_actions` say when to `neuromesh_expand_fold`. Gr
 | `neuromesh_get_file_skeleton` | `file_path`, optional `active_symbols` | One skeletonized file |
 | `neuromesh_search_symbols` | `query`, optional `limit` | Ranked hits |
 | `neuromesh_get_dependencies` | name or path | Typed neighbors |
-| `neuromesh_trace` | `query`, `direction` (`in` / `out` / `both`), `depth` | Call/import chains |
+| `neuromesh_trace` | `query`, `direction` (`in` / `out` / `both`), `depth` | Call/import chains. Inbound includes `throw new`, `throw $e` after `catch (Type $e)`, and ternary `new Type`. Trace the exception that is actually thrown. |
 | `neuromesh_analyze_impact` | `query`, `depth` | Blast radius |
 | `neuromesh_get_architecture` | — | Languages, packages, entry points |
 | `neuromesh_get_project_memory` | — | Seeded facts |

--- a/editors/vscode-neuromesh/README.md
+++ b/editors/vscode-neuromesh/README.md
@@ -2,7 +2,7 @@
 
 Sidebar mesh stats, a packet inspector, fold CodeLens, and the galaxy UI — talking to a running `neuromesh monitor`.
 
-The agent loop in the editor matches 0.6.2: **get_context → expand_fold**. Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**.
+The agent loop in the editor matches 0.6.3: **get_context → expand_fold**. Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**.
 
 ## Install
 

--- a/editors/vscode-neuromesh/package.json
+++ b/editors/vscode-neuromesh/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-neuromesh",
   "displayName": "NeuroMesh",
   "description": "Evidence packets, reversible folds, and a live mesh sidebar for Cursor & VS Code. Don’t dump files — fold them.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publisher": "neuromesh",
   "license": "MIT",
   "homepage": "https://github.com/pinoox/neuromesh",


### PR DESCRIPTION
Inbound throw edges for PHP rethrow and ternary `new Type`.

- **Inbound throws.** `throw $e` after `catch (Type $e)`, catch unions, and ternary `throw … new Type` become inbound `Calls` edges. Symfony matchers throw `ResourceNotFoundException`, not `RouteNotFoundException` — trace the type that is actually constructed or caught.