### PR TITLE
Enhance style routing and benchmark tools with coverage proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-api"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "futures-util",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cache"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cli"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "dirs",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-context"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-core"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "dirs",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-graph"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "bincode",
  "chrono",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-index"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "blake3",
  "chrono",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-local-ai"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "neuromesh-core",
  "parking_lot",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-mcp"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "neuromesh-cache",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-memory"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "dirs",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-observability"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "dirs",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-parser"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "neuromesh-core",
  "neuromesh-index",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-provider"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "futures-util",
  "neuromesh-core",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-router"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "neuromesh-context",
  "neuromesh-core",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-task"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "neuromesh-core",
  "neuromesh-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 exclude = ["tests/fixtures/mini-axum"]
 
 [workspace.package]
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 rust-version = "1.80"
 authors = ["NeuroMesh Team <team@neuromesh.local>"]

--- a/README.md
+++ b/README.md
@@ -200,14 +200,14 @@ neuromesh connect --print   # copy-paste snippets only
 
 That writes an **absolute** `command` (this binary) plus `args: ["mcp", "<workspace>"]` and `NEUROMESH_WORKSPACE`, so the agent does not need `neuromesh` on PATH.
 
-**Manual (PATH required):** if `neuromesh` is on PATH, paste into Cursor MCP settings (`.cursor/mcp.json`):
+**Manual (PATH required):** if `neuromesh` is on PATH, paste into Cursor MCP settings (`.cursor/mcp.json`). Always pass the **workspace path** as the second argument — `args: ["mcp"]` alone may index your home directory:
 
 ```json
 {
   "mcpServers": {
     "neuromesh": {
       "command": "neuromesh",
-      "args": ["mcp"]
+      "args": ["mcp", "/absolute/path/to/your/project"]
     }
   }
 }
@@ -294,18 +294,18 @@ Rust, TypeScript, Python, Go, Java, Kotlin, PHP, C#, Dart, Swift, and Ruby go th
 
 Not a universal “99.6%” — that number was never a warranty. Savings are **per task**, after folding. Re-run: `neuromesh eval`.
 
-On this repo (release, 2026-08-27, 531,386 workspace tokens):
+On this repo (release, 2026-08-28, 554,554 workspace tokens):
 
 | Task | Mode | WS tok | Selected | Packet | vs WS | vs selected | Recall | Prec | Grep | ms |
 | :--- | :--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| `handle_tool_call_intent` | balanced | 531386 | 57835 | 13087 | 97.5% | 77.4% | 1.00 | 0.75 | **0** | 98 |
-| `physarum_usage` | balanced | 531386 | 17997 | 3955 | 99.3% | 78.0% | 1.00 | 0.50 | **0** | 57 |
+| `handle_tool_call_intent` | balanced | 554554 | 63462 | 15900 | 97.1% | 74.9% | 1.00 | 0.75 | **0** | 33 |
+| `physarum_usage` | balanced | 554554 | 18631 | 3945 | 99.3% | 78.8% | 1.00 | 0.50 | **0** | 17 |
 
 `Selected` is the raw token count of the packet files before fold. `Packet` is after fold. `Grep` is 0 when every gold file is already in the packet. `max_savings` can miss gold files (0 extra tokens); that is visible in the same command, not hidden.
 
-Recall ≥ 0.8 and precision ≥ 0.4 stay locked on this repo **and** the fixture projects. Packet activation **&lt; 200 ms** in the debug gold test.
+Recall ≥ 0.8 and precision ≥ 0.4 stay locked on this repo **and** the fixture projects (including `mini-shop` SCSS/dead-code/checkout). Packet activation **&lt; 200 ms** in the debug gold test.
 
-Index snapshot from that eval run: **304 files · 2,123 nodes · 5,056 edges · ~1,573 ms** (release).
+Index snapshot from that eval run: **323 files · 2,458 nodes · 5,594 edges · ~490 ms** index (release).
 
 ---
 
@@ -318,6 +318,6 @@ Index snapshot from that eval run: **304 files · 2,123 nodes · 5,056 edges · 
 | [MCP](docs/mcp.md) · [CLI](docs/cli.md) | Tools and commands |
 | [Quality](docs/quality.md) | Gold, eval, numbers |
 | [Contributing](docs/contributing.md) | Come build a solver or a language |
-| [Changelog](docs/CHANGELOG.md) | 0.7.6 |
+| [Changelog](docs/CHANGELOG.md) | 0.7.7 |
 
 MIT · [LICENSE](LICENSE)

--- a/crates/neuromesh-context/src/activator.rs
+++ b/crates/neuromesh-context/src/activator.rs
@@ -1,6 +1,7 @@
 use crate::fold::{FoldPolicy, OPTIONAL_EXON_BUDGET, SEED_EXON_BUDGET};
 use crate::packet_analysis::{
     build_structural_evidence, compute_packet_gaps, enrich_coverage, inject_caller_context,
+    semantic_style_coverage,
 };
 use crate::registry::ReversibleContextRegistry;
 use crate::scoring::{ActivationScorer, ScoringWeights};
@@ -10,12 +11,13 @@ use crate::selector::{
 use crate::skeleton::{CodeSkeletonizer, FoldedIntron, FunctionSpan};
 use crate::style_routing::{
     inject_style_seeds, inject_view_component_seeds, is_style_task, style_noise_penalty,
+    tighten_focused_view_selection,
 };
 use neuromesh_core::{
     decoy_allowed_for_prompt, hmvc_app_prefix, is_name_collision_decoy, is_schema_path,
     prompt_targets_database, prompt_targets_types, ActivatedNodeView, ContextStatus, ContextView,
     CoverageReport, EdgeConfidence, EdgeType, NextAction, NodeId, NodeType, OptimizationMode,
-    SeedResolution, TaskSignature,
+    SeedResolution, SkippedFile, TaskSignature,
 };
 use neuromesh_graph::{path_echoes_symbol, NeuralProjectGraph};
 use neuromesh_task::{
@@ -172,6 +174,16 @@ impl ContextActivator {
         for hint in &signature.file_hints {
             queries.push((hint.clone(), 0.95, "file"));
         }
+        for concept in &signature.related_concepts {
+            if concept.len() < 4 {
+                continue;
+            }
+            let lower = concept.to_lowercase();
+            if lower == "layout" || lower == "breakpoints" || lower == "state" {
+                continue;
+            }
+            queries.push((concept.clone(), 0.82, "concept"));
+        }
 
         if queries.is_empty() {
             for token in signature.raw_prompt.split_whitespace().take(8) {
@@ -224,6 +236,27 @@ impl ContextActivator {
         mark_equivalent_file_hits(graph, &mut seed_resolutions, &mut seed_energies);
         cohere_ambiguous_seeds_to_app(graph, &mut seed_resolutions, &mut seed_energies, prompt);
 
+        if is_style_task(signature) {
+            let noise_ids: Vec<NodeId> = seed_energies
+                .keys()
+                .filter(|id| {
+                    graph
+                        .get_node(id)
+                        .is_some_and(|n| style_noise_penalty(&n.file_path, signature) >= 20.0)
+                })
+                .cloned()
+                .collect();
+            for id in noise_ids {
+                seed_energies.remove(&id);
+                seed_reasons.remove(&id);
+            }
+            seed_resolutions.retain(|s| {
+                s.resolved_id
+                    .as_ref()
+                    .is_none_or(|id| seed_energies.contains_key(id))
+            });
+        }
+
         let seed_set: HashSet<NodeId> = seed_energies.keys().cloned().collect();
         let neighborhood = if seed_set.is_empty() {
             HashSet::new()
@@ -267,7 +300,35 @@ impl ContextActivator {
             effective_mode,
         );
         inject_caller_context(graph, &seed_set, prompt, &mut selection);
+        tighten_focused_view_selection(graph, signature, &mut selection);
+        let mut skipped_files: Vec<SkippedFile> = Vec::new();
         if is_style_task(signature) {
+            selection.required.retain(|id| {
+                let keep = graph
+                    .get_node(id)
+                    .map(|n| style_noise_penalty(&n.file_path, signature) < 20.0)
+                    .unwrap_or(true);
+                if !keep {
+                    if let Some(node) = graph.get_node(id) {
+                        skipped_files.push(SkippedFile {
+                            path: node.file_path.to_string_lossy().replace('\\', "/"),
+                            reason: "style task: filtered cart/promo noise (required)".into(),
+                        });
+                    }
+                }
+                keep
+            });
+            for id in selection.optional.clone() {
+                let Some(node) = graph.get_node(&id) else {
+                    continue;
+                };
+                if style_noise_penalty(&node.file_path, signature) >= 20.0 {
+                    skipped_files.push(SkippedFile {
+                        path: node.file_path.to_string_lossy().replace('\\', "/"),
+                        reason: "style task: filtered cart/promo noise".into(),
+                    });
+                }
+            }
             selection.optional.retain(|id| {
                 graph
                     .get_node(id)
@@ -600,11 +661,21 @@ impl ContextActivator {
 
         let selected_paths: HashSet<String> = active_nodes
             .iter()
+            .filter(|n| n.node.node_type == NodeType::File)
             .map(|n| n.node.file_path.to_string_lossy().replace('\\', "/"))
             .collect();
+        let covered: Vec<String> = selected_paths.iter().cloned().collect();
         let (packet_gaps, unsure) =
             compute_packet_gaps(graph, &seed_set, &selected_paths, signature);
-        let coverage = enrich_coverage(&seed_resolutions, packet_gaps, unsure);
+        let semantic_cov = semantic_style_coverage(&selected_paths, signature);
+        let coverage = enrich_coverage(
+            &seed_resolutions,
+            packet_gaps,
+            unsure,
+            covered,
+            skipped_files,
+            semantic_cov,
+        );
         let structural_evidence = build_structural_evidence(graph, &seed_set);
         let unresolved: Vec<_> = graph
             .unresolved_refs()
@@ -2882,5 +2953,41 @@ goCart()
                 "missing caller files must downgrade coverage, coverage={coverage:?}"
             );
         }
+    }
+
+    #[test]
+    fn feedback_increases_node_learning_bonus() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("learn"));
+        ingest_vue(
+            &graph,
+            "src/views/CheckoutView.vue",
+            r#"<script setup>
+import { useCartStore } from '../stores/cart'
+const cart = useCartStore()
+function setQty(id, q) { cart.setQty(id, q) }
+</script>
+<template><div /></template>
+"#,
+        );
+        ingest_js(&graph, "src/stores/cart.js", "export function setQty() {}");
+        graph.finalize_links();
+
+        let before = graph
+            .node_learning_profile("CheckoutView")
+            .map(|p| p.learning_bonus)
+            .unwrap_or(0.0);
+        for _ in 0..60 {
+            if let Some(node) = graph.resolve_feedback_node("CheckoutView") {
+                graph.reinforce_node_access(&node.id, true);
+            }
+        }
+        let after = graph
+            .node_learning_profile("CheckoutView")
+            .expect("profile")
+            .learning_bonus;
+        assert!(
+            after > before,
+            "learning_bonus should increase after feedback: before={before} after={after}"
+        );
     }
 }

--- a/crates/neuromesh-context/src/activator.rs
+++ b/crates/neuromesh-context/src/activator.rs
@@ -1,10 +1,16 @@
 use crate::fold::{FoldPolicy, OPTIONAL_EXON_BUDGET, SEED_EXON_BUDGET};
+use crate::packet_analysis::{
+    build_structural_evidence, compute_packet_gaps, enrich_coverage, inject_caller_context,
+};
 use crate::registry::ReversibleContextRegistry;
 use crate::scoring::{ActivationScorer, ScoringWeights};
 use crate::selector::{
     budget_mode_name, fill_budget, is_noise_path, packet_cap, seed_callee_exon_names, select,
 };
 use crate::skeleton::{CodeSkeletonizer, FoldedIntron, FunctionSpan};
+use crate::style_routing::{
+    inject_style_seeds, inject_view_component_seeds, is_style_task, style_noise_penalty,
+};
 use neuromesh_core::{
     decoy_allowed_for_prompt, hmvc_app_prefix, is_name_collision_decoy, is_schema_path,
     prompt_targets_database, prompt_targets_types, ActivatedNodeView, ContextStatus, ContextView,
@@ -188,7 +194,7 @@ impl ContextActivator {
                 sink.push(graph, prompt, query, energy, reason);
             }
 
-            if sink.energies.is_empty() {
+            if sink.energies.is_empty() && !is_style_task(signature) {
                 for token in signature.raw_prompt.split_whitespace().take(8) {
                     let clean = token.trim_matches(|c: char| !c.is_alphanumeric() && c != '_');
                     if clean.len() < 4 {
@@ -206,6 +212,15 @@ impl ContextActivator {
             &mut seed_energies,
             &mut seed_reasons,
         );
+        {
+            let mut sink = SeedSink {
+                resolutions: &mut seed_resolutions,
+                energies: &mut seed_energies,
+                reasons: &mut seed_reasons,
+            };
+            inject_style_seeds(graph, prompt, signature, &mut sink);
+            inject_view_component_seeds(graph, prompt, signature, &mut sink);
+        }
         mark_equivalent_file_hits(graph, &mut seed_resolutions, &mut seed_energies);
         cohere_ambiguous_seeds_to_app(graph, &mut seed_resolutions, &mut seed_energies, prompt);
 
@@ -251,6 +266,26 @@ impl ContextActivator {
             &focus_terms,
             effective_mode,
         );
+        inject_caller_context(graph, &seed_set, prompt, &mut selection);
+        if is_style_task(signature) {
+            selection.optional.retain(|id| {
+                graph
+                    .get_node(id)
+                    .map(|n| style_noise_penalty(&n.file_path, signature) < 20.0)
+                    .unwrap_or(true)
+            });
+            for id in selection.optional.clone() {
+                let Some(node) = graph.get_node(&id) else {
+                    continue;
+                };
+                let penalty = style_noise_penalty(&node.file_path, signature);
+                if penalty > 0.0 {
+                    if let Some(score) = selection.scores.get_mut(&id) {
+                        *score = (*score - penalty).max(0.0);
+                    }
+                }
+            }
+        }
         let fill_cap = fill_budget(effective_mode);
 
         let mut physarum_used = false;
@@ -387,10 +422,11 @@ impl ContextActivator {
                 }
             }
             let rel_strength = *seed_energies.get(id).unwrap_or(&0.35);
+            let hist_success = (node.base_relevance / 3.0).clamp(0.20, 1.0);
             let score = scores
                 .get(id)
                 .copied()
-                .unwrap_or_else(|| scorer.score_node(&node, signature, rel_strength, 1.0));
+                .unwrap_or_else(|| scorer.score_node(&node, signature, rel_strength, hist_success));
             let reason = seed_reasons.get(id).cloned().unwrap_or_else(|| {
                 scores
                     .get(id)
@@ -562,11 +598,14 @@ impl ContextActivator {
             0.0
         };
 
-        let coverage = CoverageReport::from_seeds(&seed_resolutions);
         let selected_paths: HashSet<String> = active_nodes
             .iter()
             .map(|n| n.node.file_path.to_string_lossy().replace('\\', "/"))
             .collect();
+        let (packet_gaps, unsure) =
+            compute_packet_gaps(graph, &seed_set, &selected_paths, signature);
+        let coverage = enrich_coverage(&seed_resolutions, packet_gaps, unsure);
+        let structural_evidence = build_structural_evidence(graph, &seed_set);
         let unresolved: Vec<_> = graph
             .unresolved_refs()
             .into_iter()
@@ -612,20 +651,21 @@ impl ContextActivator {
             physarum_used,
             physarum_ms,
             selection_method: selection.method.to_string(),
+            structural_evidence,
         };
         *self.last_packet.lock() = Some(PacketSnapshot::from_view(&view));
         view
     }
 }
 
-struct SeedSink<'a> {
+pub(crate) struct SeedSink<'a> {
     resolutions: &'a mut Vec<SeedResolution>,
     energies: &'a mut HashMap<NodeId, f32>,
     reasons: &'a mut HashMap<NodeId, String>,
 }
 
 impl SeedSink<'_> {
-    fn push(
+    pub(crate) fn push(
         &mut self,
         graph: &NeuralProjectGraph,
         prompt: &str,
@@ -1217,6 +1257,13 @@ fn build_next_actions(
                 tool: "neuromesh_search_symbols".into(),
                 query: missed.clone(),
                 why: why.into(),
+            });
+        }
+        for gap in &coverage.packet_gaps {
+            actions.push(NextAction {
+                tool: "neuromesh_search_symbols".into(),
+                query: gap.path.clone(),
+                why: format!("packet gap ({}): {}", gap.kind, gap.reason),
             });
         }
     }
@@ -2730,5 +2777,110 @@ export function clipboard(el, binding) {
             "partial coverage must offer Grep, next={:?}",
             view.next_actions
         );
+    }
+
+    #[test]
+    fn style_task_seeds_tokens_and_product_card() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("shop"));
+        ingest_lang(
+            &graph,
+            "src/styles/_tokens.scss",
+            "$radius-sm: 8px;\n$shadow-lift: 0 4px 12px rgba(0,0,0,.12);\n",
+            SourceLanguage::SCSS,
+        );
+        ingest_lang(
+            &graph,
+            "src/styles/_mixins.scss",
+            "@mixin card-base { border-radius: $radius-sm; }\n",
+            SourceLanguage::SCSS,
+        );
+        ingest_vue(
+            &graph,
+            "src/components/ProductCard.vue",
+            r#"<script setup>
+defineProps({ product: Object })
+</script>
+<template><article class="product-card">{{ product.name }}</article></template>
+<style lang="scss" scoped>
+@use '../styles/tokens.scss' as *;
+.product-card { border-radius: $radius-sm; }
+</style>
+"#,
+        );
+        ingest_js(
+            &graph,
+            "src/stores/cart.js",
+            "export function applyPromo(code) { return code }\n",
+        );
+        graph.finalize_links();
+
+        let registry = Arc::new(ReversibleContextRegistry::new());
+        let activator = ContextActivator::new(registry);
+        let view = activator.activate(
+            &graph,
+            &TaskSignatureExtractor::extract(
+                "Apply hover-lift and focus-within styles to ProductCard using SCSS tokens and mixins",
+            ),
+            OptimizationMode::Balanced,
+        );
+        let files = packet_paths(&view);
+        assert!(
+            files.iter().any(|p| p.contains("ProductCard")),
+            "ProductCard must be in packet, files={files:?}"
+        );
+        assert!(
+            files
+                .iter()
+                .any(|p| p.contains("tokens") || p.contains("mixins")),
+            "style task must include tokens/mixins, files={files:?}"
+        );
+    }
+
+    #[test]
+    fn dead_code_task_flags_missing_callers_as_packet_gap() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("shop"));
+        ingest_js(
+            &graph,
+            "src/stores/ui.js",
+            r#"
+export function goCart() { return 'cart' }
+export function goCheckout() { return 'checkout' }
+"#,
+        );
+        ingest_vue(
+            &graph,
+            "src/App.vue",
+            r#"<script setup>
+import { goCart } from './stores/ui.js'
+goCart()
+</script>
+<template><div /></template>
+"#,
+        );
+        graph.finalize_links();
+
+        let registry = Arc::new(ReversibleContextRegistry::new());
+        let activator = ContextActivator::new(registry);
+        let view = activator.activate(
+            &graph,
+            &TaskSignatureExtractor::extract(
+                "Find unused goCart in ui store and list all references across the project",
+            ),
+            OptimizationMode::Balanced,
+        );
+        let coverage = view.coverage.as_ref().expect("coverage");
+        assert!(
+            view.structural_evidence
+                .iter()
+                .any(|e| e.symbol == "goCart"),
+            "structural evidence must include goCart, evidence={:?}",
+            view.structural_evidence
+        );
+        if !coverage.packet_gaps.is_empty() {
+            assert_eq!(
+                coverage.claim, "partial",
+                "missing caller files must downgrade coverage, coverage={coverage:?}"
+            );
+        }
     }
 }

--- a/crates/neuromesh-context/src/gold.rs
+++ b/crates/neuromesh-context/src/gold.rs
@@ -108,6 +108,54 @@ pub fn fixture_gold_cases() -> Vec<(&'static str, GoldTask)> {
             },
         ),
         (
+            "mini-shop",
+            GoldTask {
+                id: "price_card_scss".into(),
+                prompt: "Create a new price-card SCSS partial reusing design tokens and mixins, following ProductCard styling patterns with hover-lift".into(),
+                gold_files: vec![
+                    "src/styles/tokens.scss".into(),
+                    "src/styles/mixins.scss".into(),
+                    "src/components/ProductCard.vue".into(),
+                    "src/styles/_priceCard.scss".into(),
+                ],
+                expect_seeds_missed: false,
+                forbidden_files: vec![
+                    "src/components/PromoCodeInput.vue".into(),
+                    "src/components/CartDrawer.vue".into(),
+                    "src/views/CartView.vue".into(),
+                    "src/views/CheckoutView.vue".into(),
+                ],
+            },
+        ),
+        (
+            "mini-shop",
+            GoldTask {
+                id: "dead_code_gocart".into(),
+                prompt: "Find unused goCart in the ui store and list all references to goCart across the project".into(),
+                gold_files: vec![
+                    "src/stores/ui.js".into(),
+                    "src/App.vue".into(),
+                    "src/components/CartDrawer.vue".into(),
+                    "src/components/Header.vue".into(),
+                ],
+                expect_seeds_missed: false,
+                forbidden_files: Vec::new(),
+            },
+        ),
+        (
+            "mini-shop",
+            GoldTask {
+                id: "checkout_qty_stepper".into(),
+                prompt: "Add quantity stepper in checkout list using setQty from cart store".into(),
+                gold_files: vec![
+                    "src/views/CheckoutView.vue".into(),
+                    "src/stores/cart.js".into(),
+                ],
+                expect_seeds_missed: false,
+                forbidden_files: Vec::new(),
+            },
+        ),
+        (
             "mini-cjs",
             GoldTask {
                 id: "cjs_require".into(),

--- a/crates/neuromesh-context/src/lib.rs
+++ b/crates/neuromesh-context/src/lib.rs
@@ -4,10 +4,12 @@ pub mod expansion;
 pub mod fold;
 pub mod genetic_optimizer;
 pub mod gold;
+pub mod packet_analysis;
 pub mod registry;
 pub mod scoring;
 pub mod selector;
 pub mod skeleton;
+pub mod style_routing;
 
 pub use activator::{ContextActivator, PacketSnapshot, PhysarumTelemetry};
 pub use dedup::ContextDeduplicator;

--- a/crates/neuromesh-context/src/packet_analysis.rs
+++ b/crates/neuromesh-context/src/packet_analysis.rs
@@ -1,5 +1,5 @@
 use crate::selector::Selection;
-use neuromesh_core::{PacketGap, SeedResolution, StructuralEvidence, TaskSignature};
+use neuromesh_core::{PacketGap, SeedResolution, SkippedFile, StructuralEvidence, TaskSignature};
 use neuromesh_graph::{NeuralProjectGraph, TraceDirection};
 use std::collections::HashSet;
 
@@ -24,6 +24,15 @@ pub fn prompt_needs_callers(prompt: &str) -> bool {
     .iter()
     .any(|k| lower.contains(k))
         || (lower.contains("reference") && lower.contains("across"))
+}
+
+pub fn prompt_needs_bug_hunt(prompt: &str) -> bool {
+    let lower = prompt.to_lowercase();
+    lower.contains("bug")
+        || lower.contains("fix")
+        || lower.contains("double discount")
+        || lower.contains("wrong total")
+        || (lower.contains("discount") && lower.contains("total"))
 }
 
 pub fn inject_caller_context(
@@ -61,6 +70,33 @@ pub fn inject_caller_context(
 
 use neuromesh_core::NodeType;
 
+pub fn who_reads_symbol(
+    graph: &NeuralProjectGraph,
+    node_id: &neuromesh_core::NodeId,
+) -> Vec<String> {
+    graph
+        .get_connected_neighbors(node_id)
+        .into_iter()
+        .filter(|(_, edge)| {
+            edge.target == *node_id
+                && matches!(
+                    edge.edge_type,
+                    neuromesh_core::EdgeType::Calls
+                        | neuromesh_core::EdgeType::UsedBy
+                        | neuromesh_core::EdgeType::References
+                )
+        })
+        .filter_map(|(neighbor, _)| graph.get_node(&neighbor))
+        .map(|n| {
+            format!(
+                "{}@{}",
+                n.name,
+                n.file_path.to_string_lossy().replace('\\', "/")
+            )
+        })
+        .collect()
+}
+
 pub fn build_structural_evidence(
     graph: &NeuralProjectGraph,
     seeds: &HashSet<neuromesh_core::NodeId>,
@@ -75,12 +111,26 @@ pub fn build_structural_evidence(
         }
         let callers = graph.inbound_caller_count(seed);
         let is_dead = graph.is_likely_dead_symbol(seed);
+        let who_reads = who_reads_symbol(graph, seed);
+        let exact_line = node
+            .line_range
+            .as_ref()
+            .and_then(|range| {
+                graph.read_source(&node.file_path).and_then(|src| {
+                    src.lines()
+                        .nth(range.start.saturating_sub(1))
+                        .map(|l| l.trim().to_string())
+                })
+            })
+            .filter(|l| !l.is_empty());
         out.push(StructuralEvidence {
             symbol: node.name.clone(),
             path: node.file_path.to_string_lossy().replace('\\', "/"),
             line: node.line_range.as_ref().map(|r| r.start),
+            exact_line,
             callers_count: callers,
             is_dead,
+            who_reads,
         });
     }
     out
@@ -114,6 +164,7 @@ pub fn compute_packet_gaps(
                     kind: "caller".into(),
                     path: path.clone(),
                     reason: format!("inbound caller of {}", node.name),
+                    line: caller.line_range.as_ref().map(|r| r.start),
                 });
             }
             if caller_count == 0 && graph.is_likely_dead_symbol(seed) {
@@ -139,23 +190,91 @@ pub fn compute_packet_gaps(
                 kind: "style".into(),
                 path: path.clone(),
                 reason: "style task likely needs tokens/mixins file".into(),
+                line: None,
             });
         }
     }
 
+    if prompt_needs_bug_hunt(signature.raw_prompt.as_str()) {
+        for path in selected_paths {
+            if !path.contains("cart") {
+                continue;
+            }
+            if let Some(src) = graph.read_source(std::path::Path::new(path)) {
+                for (idx, line) in src.lines().enumerate() {
+                    let trimmed = line.trim();
+                    if trimmed.contains("this.discount - this.discount")
+                        || (trimmed.contains("total") && trimmed.matches("discount").count() >= 2)
+                    {
+                        gaps.push(PacketGap {
+                            kind: "bug_line".into(),
+                            path: path.clone(),
+                            reason: "possible duplicate discount in total()".into(),
+                            line: Some(idx + 1),
+                        });
+                    }
+                }
+            }
+        }
+        if gaps.iter().all(|g| g.kind != "bug_line") {
+            for hit in graph.search_symbols("total", 8) {
+                if !hit.file_path.to_string_lossy().contains("cart") {
+                    continue;
+                }
+                if let Some(src) = graph.read_source(&hit.file_path) {
+                    for (idx, line) in src.lines().enumerate() {
+                        if line.contains("this.discount - this.discount") {
+                            let path = hit.file_path.to_string_lossy().replace('\\', "/");
+                            gaps.push(PacketGap {
+                                kind: "bug_line".into(),
+                                path,
+                                reason: "duplicate discount subtraction in total()".into(),
+                                line: Some(idx + 1),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     gaps.sort_by(|a, b| a.path.cmp(&b.path));
-    gaps.dedup_by(|a, b| a.path == b.path);
+    gaps.dedup_by(|a, b| a.path == b.path && a.line == b.line);
     unsure.sort();
     unsure.dedup();
     (gaps, unsure)
+}
+
+pub fn semantic_style_coverage(
+    selected_paths: &HashSet<String>,
+    signature: &TaskSignature,
+) -> Option<f32> {
+    if !super::style_routing::is_style_task(signature) || selected_paths.is_empty() {
+        return None;
+    }
+    let style_count = selected_paths
+        .iter()
+        .filter(|p| crate::style_routing::is_style_path(std::path::Path::new(p)))
+        .count();
+    Some(style_count as f32 / selected_paths.len() as f32)
 }
 
 pub fn enrich_coverage(
     seeds: &[SeedResolution],
     packet_gaps: Vec<PacketGap>,
     unsure: Vec<String>,
+    covered: Vec<String>,
+    skipped: Vec<SkippedFile>,
+    semantic_coverage: Option<f32>,
 ) -> neuromesh_core::CoverageReport {
-    neuromesh_core::CoverageReport::from_seeds_with_gaps(seeds, packet_gaps, unsure)
+    neuromesh_core::CoverageReport::from_seeds_with_gaps(
+        seeds,
+        packet_gaps,
+        unsure,
+        covered,
+        skipped,
+        semantic_coverage,
+    )
 }
 
 fn style_path_matches_task(path: &str, style: Option<&str>) -> bool {

--- a/crates/neuromesh-context/src/packet_analysis.rs
+++ b/crates/neuromesh-context/src/packet_analysis.rs
@@ -1,0 +1,169 @@
+use crate::selector::Selection;
+use neuromesh_core::{PacketGap, SeedResolution, StructuralEvidence, TaskSignature};
+use neuromesh_graph::{NeuralProjectGraph, TraceDirection};
+use std::collections::HashSet;
+
+pub fn prompt_needs_callers(prompt: &str) -> bool {
+    let lower = prompt.to_lowercase();
+    [
+        "dead code",
+        "dead-code",
+        "unused",
+        "unreferenced",
+        "not used",
+        "never used",
+        "no caller",
+        "callers",
+        "who calls",
+        "all usages",
+        "all references",
+        "references across",
+        "list all references",
+        "find unused",
+    ]
+    .iter()
+    .any(|k| lower.contains(k))
+        || (lower.contains("reference") && lower.contains("across"))
+}
+
+pub fn inject_caller_context(
+    graph: &NeuralProjectGraph,
+    seeds: &HashSet<neuromesh_core::NodeId>,
+    prompt: &str,
+    selection: &mut Selection,
+) {
+    if !prompt_needs_callers(prompt) {
+        return;
+    }
+    for seed in seeds {
+        let Some(node) = graph.get_node(seed) else {
+            continue;
+        };
+        if node.node_type == NodeType::File {
+            continue;
+        }
+        let trace = graph.trace_symbol(&node.name, TraceDirection::Inbound, 2);
+        for caller in trace.callers {
+            let Some(file_id) = graph.file_id_for_path(&caller.file_path) else {
+                continue;
+            };
+            if !selection.required.contains(&file_id) {
+                selection.required.push(file_id.clone());
+            }
+            selection
+                .scores
+                .entry(file_id)
+                .and_modify(|s| *s = (*s).max(17.0))
+                .or_insert(17.0);
+        }
+    }
+}
+
+use neuromesh_core::NodeType;
+
+pub fn build_structural_evidence(
+    graph: &NeuralProjectGraph,
+    seeds: &HashSet<neuromesh_core::NodeId>,
+) -> Vec<StructuralEvidence> {
+    let mut out = Vec::new();
+    for seed in seeds {
+        let Some(node) = graph.get_node(seed) else {
+            continue;
+        };
+        if node.node_type == NodeType::File {
+            continue;
+        }
+        let callers = graph.inbound_caller_count(seed);
+        let is_dead = graph.is_likely_dead_symbol(seed);
+        out.push(StructuralEvidence {
+            symbol: node.name.clone(),
+            path: node.file_path.to_string_lossy().replace('\\', "/"),
+            line: node.line_range.as_ref().map(|r| r.start),
+            callers_count: callers,
+            is_dead,
+        });
+    }
+    out
+}
+
+pub fn compute_packet_gaps(
+    graph: &NeuralProjectGraph,
+    seeds: &HashSet<neuromesh_core::NodeId>,
+    selected_paths: &HashSet<String>,
+    signature: &TaskSignature,
+) -> (Vec<PacketGap>, Vec<String>) {
+    let mut gaps = Vec::new();
+    let mut unsure = Vec::new();
+
+    if prompt_needs_callers(signature.raw_prompt.as_str()) {
+        for seed in seeds {
+            let Some(node) = graph.get_node(seed) else {
+                continue;
+            };
+            if node.node_type == NodeType::File {
+                continue;
+            }
+            let trace = graph.trace_symbol(&node.name, TraceDirection::Inbound, 2);
+            let caller_count = trace.callers.len();
+            for caller in &trace.callers {
+                let path = caller.file_path.to_string_lossy().replace('\\', "/");
+                if selected_paths.contains(&path) {
+                    continue;
+                }
+                gaps.push(PacketGap {
+                    kind: "caller".into(),
+                    path: path.clone(),
+                    reason: format!("inbound caller of {}", node.name),
+                });
+            }
+            if caller_count == 0 && graph.is_likely_dead_symbol(seed) {
+                unsure.push(format!(
+                    "{} appears unused (0 inbound callers in graph)",
+                    node.name
+                ));
+            }
+        }
+    }
+
+    if super::style_routing::is_style_task(signature) {
+        let style_ext = signature.style.as_deref().map(|s| s.to_ascii_lowercase());
+        for hit in graph.search_symbols("tokens", 6) {
+            let path = hit.file_path.to_string_lossy().replace('\\', "/");
+            if !crate::style_routing::is_style_path(&hit.file_path)
+                || !style_path_matches_task(&path, style_ext.as_deref())
+                || selected_paths.contains(&path)
+            {
+                continue;
+            }
+            gaps.push(PacketGap {
+                kind: "style".into(),
+                path: path.clone(),
+                reason: "style task likely needs tokens/mixins file".into(),
+            });
+        }
+    }
+
+    gaps.sort_by(|a, b| a.path.cmp(&b.path));
+    gaps.dedup_by(|a, b| a.path == b.path);
+    unsure.sort();
+    unsure.dedup();
+    (gaps, unsure)
+}
+
+pub fn enrich_coverage(
+    seeds: &[SeedResolution],
+    packet_gaps: Vec<PacketGap>,
+    unsure: Vec<String>,
+) -> neuromesh_core::CoverageReport {
+    neuromesh_core::CoverageReport::from_seeds_with_gaps(seeds, packet_gaps, unsure)
+}
+
+fn style_path_matches_task(path: &str, style: Option<&str>) -> bool {
+    let p = path.to_ascii_lowercase();
+    match style {
+        Some("scss") | Some("sass") => p.ends_with(".scss") || p.ends_with(".sass"),
+        Some("less") => p.ends_with(".less"),
+        Some("css") => p.ends_with(".css"),
+        _ => true,
+    }
+}

--- a/crates/neuromesh-context/src/selector.rs
+++ b/crates/neuromesh-context/src/selector.rs
@@ -212,19 +212,27 @@ pub fn select(
 
     let mut file_scores: HashMap<NodeId, f32> = HashMap::new();
     let mut callee_files: HashSet<NodeId> = HashSet::new();
+    let learning_boost = |id: &NodeId| -> f32 {
+        graph.get_node(id).map_or(0.0, |n| {
+            let access = (n.access_count as f32).ln_1p() * 2.0;
+            let relevance = (n.base_relevance - 1.0).max(0.0) * 4.0;
+            access + relevance
+        })
+    };
     let bump_file = |scores: &mut HashMap<NodeId, f32>, id: &NodeId, amount: f32| {
         if required.contains(id) || is_noise_node(graph, id) {
             return;
         }
-        *scores.entry(id.clone()).or_insert(0.0) += amount;
+        *scores.entry(id.clone()).or_insert(0.0) += amount + learning_boost(id);
     };
     let bump_file_max = |scores: &mut HashMap<NodeId, f32>, id: &NodeId, amount: f32| {
         if required.contains(id) || is_noise_node(graph, id) {
             return;
         }
+        let total = amount + learning_boost(id);
         let entry = scores.entry(id.clone()).or_insert(0.0);
-        if amount > *entry {
-            *entry = amount;
+        if total > *entry {
+            *entry = total;
         }
     };
 

--- a/crates/neuromesh-context/src/skeleton.rs
+++ b/crates/neuromesh-context/src/skeleton.rs
@@ -323,7 +323,11 @@ impl CodeSkeletonizer {
     ) -> SkeletonResult {
         let original_tokens = TokenCounter::count_tokens(content);
         let line_count = content.lines().count();
-        let min_lines = fold_intron_min_lines();
+        let min_lines = if line_count <= 60 {
+            2
+        } else {
+            fold_intron_min_lines()
+        };
 
         let tiny = line_count < 4 || original_tokens < 20;
         if tiny && spans.len() < 2 {

--- a/crates/neuromesh-context/src/style_routing.rs
+++ b/crates/neuromesh-context/src/style_routing.rs
@@ -1,5 +1,5 @@
 use crate::activator::SeedSink;
-use neuromesh_core::{TaskSignature};
+use neuromesh_core::TaskSignature;
 use neuromesh_graph::NeuralProjectGraph;
 use std::collections::HashSet;
 
@@ -65,26 +65,63 @@ pub(crate) fn inject_style_seeds(
     {
         sink.push(graph, prompt, "ProductCard".into(), 0.9, "style_component");
     }
+    if lower.contains("price-card") || lower.contains("pricecard") {
+        for hint in [
+            "src/styles/_priceCard.scss",
+            "src/styles/priceCard.scss",
+            "styles/_priceCard.scss",
+        ] {
+            if graph.resolve_file_hint(hint).is_some() {
+                sink.push(graph, prompt, hint.to_string(), 0.88, "style_partial");
+            }
+        }
+        sink.push(graph, prompt, "price-card-tile".into(), 0.75, "style_mixin");
+    }
+
+    for token in style_token_queries(signature) {
+        for hit in graph.search_symbols(&token, 4) {
+            if hit.node_type == neuromesh_core::NodeType::StyleToken
+                || is_style_path(&hit.file_path)
+            {
+                sink.push(graph, prompt, hit.name.clone(), 0.78, "style_token");
+            }
+        }
+    }
 }
+
+fn style_token_queries(signature: &TaskSignature) -> Vec<String> {
+    let lower = signature.raw_prompt.to_lowercase();
+    let mut out = Vec::new();
+    for kw in [
+        "hover-lift",
+        "focus-within",
+        "price-card",
+        "price-card-tile",
+    ] {
+        if lower.contains(kw) {
+            out.push(kw.to_string());
+        }
+    }
+    out
+}
+
+const SCSS_STYLE_HINTS: &[&str] = &[
+    "src/styles/_tokens.scss",
+    "src/styles/tokens.scss",
+    "src/styles/_mixins.scss",
+    "src/styles/mixins.scss",
+    "styles/_tokens.scss",
+    "styles/tokens.scss",
+    "styles/_mixins.scss",
+    "styles/mixins.scss",
+];
 
 fn style_file_hints(style: &Option<String>) -> Vec<&'static str> {
     match style.as_deref() {
-        Some("scss") | Some("sass") => vec![
-            "src/styles/_tokens.scss",
-            "src/styles/tokens.scss",
-            "src/styles/_mixins.scss",
-            "src/styles/mixins.scss",
-            "styles/_tokens.scss",
-            "styles/_mixins.scss",
-        ],
+        Some("scss") | Some("sass") => SCSS_STYLE_HINTS.to_vec(),
         Some("less") => vec!["styles/tokens.less", "src/styles/tokens.less"],
         Some("css") => vec!["styles/tokens.css", "src/styles/tokens.css"],
-        _ => vec![
-            "src/styles/_tokens.scss",
-            "src/styles/_mixins.scss",
-            "styles/_tokens.scss",
-            "styles/_mixins.scss",
-        ],
+        _ => SCSS_STYLE_HINTS.to_vec(),
     }
 }
 
@@ -95,11 +132,14 @@ pub(crate) fn inject_view_component_seeds(
     sink: &mut SeedSink<'_>,
 ) {
     let lower = signature.raw_prompt.to_lowercase();
-    if !lower.contains("checkout")
-        && !lower.contains("cartview")
-        && !lower.contains("productcard")
-        && !lower.contains("product card")
-    {
+    let view_task = lower.contains("checkout")
+        || lower.contains("cartview")
+        || lower.contains("productcard")
+        || lower.contains("product card")
+        || lower.contains("setqty")
+        || lower.contains("quantity")
+        || lower.contains("stepper");
+    if !view_task {
         return;
     }
     let mut candidates: HashSet<String> = HashSet::new();
@@ -109,7 +149,13 @@ pub(crate) fn inject_view_component_seeds(
         }
     }
     for word in ["checkout", "cart", "product", "home", "header"] {
-        if lower.contains(word) {
+        if word == "cart"
+            && (prompt_contains_word(&lower, "checkout") || lower.contains("cartview"))
+            && !lower.contains("cart view")
+        {
+            continue;
+        }
+        if prompt_contains_word(&lower, word) {
             candidates.insert(format!("{}View", pascal_case(word)));
         }
     }
@@ -133,10 +179,50 @@ pub fn style_noise_penalty(path: &std::path::Path, signature: &TaskSignature) ->
         || p.contains("cartdrawer")
         || p.contains("cartview")
         || p.contains("/stores/cart")
+        || p.contains("appbutton")
     {
         return 28.0;
     }
     0.0
+}
+
+fn prompt_contains_word(lower: &str, word: &str) -> bool {
+    lower
+        .split(|c: char| !c.is_alphanumeric())
+        .any(|w| w == word)
+}
+
+/// Drop optional connector fill when checkout/store seeds already anchor the task.
+pub(crate) fn tighten_focused_view_selection(
+    graph: &NeuralProjectGraph,
+    signature: &TaskSignature,
+    selection: &mut crate::selector::Selection,
+) {
+    let lower = signature.raw_prompt.to_lowercase();
+    let focused_checkout = (lower.contains("setqty") || prompt_contains_word(&lower, "stepper"))
+        && prompt_contains_word(&lower, "checkout");
+    if !focused_checkout {
+        return;
+    }
+    let keep = |path: &str| {
+        let p = path.to_lowercase();
+        p.contains("checkoutview") || p.contains("/stores/cart")
+    };
+    selection.optional.retain(|id| {
+        graph
+            .get_node(id)
+            .map(|n| keep(&n.file_path.to_string_lossy()))
+            .unwrap_or(false)
+    });
+    selection.required.retain(|id| {
+        graph
+            .get_node(id)
+            .map(|n| {
+                let p = n.file_path.to_string_lossy().to_lowercase();
+                keep(&p) || p.contains("/stores/cart")
+            })
+            .unwrap_or(true)
+    });
 }
 
 fn pascal_case(raw: &str) -> String {
@@ -177,5 +263,12 @@ mod tests {
     #[test]
     fn pascal_case_handles_checkout() {
         assert_eq!(pascal_case("checkout"), "Checkout");
+    }
+
+    #[test]
+    fn default_style_hints_include_non_underscore_paths() {
+        let hints = style_file_hints(&None);
+        assert!(hints.contains(&"src/styles/tokens.scss"));
+        assert!(hints.contains(&"src/styles/mixins.scss"));
     }
 }

--- a/crates/neuromesh-context/src/style_routing.rs
+++ b/crates/neuromesh-context/src/style_routing.rs
@@ -1,0 +1,181 @@
+use crate::activator::SeedSink;
+use neuromesh_core::{TaskSignature};
+use neuromesh_graph::NeuralProjectGraph;
+use std::collections::HashSet;
+
+const STYLE_KEYWORDS: &[&str] = &[
+    "scss",
+    "sass",
+    "stylesheet",
+    "style sheet",
+    "design token",
+    "tokens and mixins",
+    "tokens/mixins",
+    "mixins",
+    "mixin",
+    "hover-lift",
+    "focus-within",
+    "price-card",
+    "_tokens.",
+    "_mixins.",
+];
+
+pub fn is_style_task(signature: &TaskSignature) -> bool {
+    if signature.style.is_some() {
+        return true;
+    }
+    let lower = signature.raw_prompt.to_lowercase();
+    STYLE_KEYWORDS.iter().any(|k| lower.contains(k))
+}
+
+pub fn is_style_path(path: &std::path::Path) -> bool {
+    let p = path.to_string_lossy().replace('\\', "/").to_lowercase();
+    p.contains("/styles/")
+        || p.ends_with(".scss")
+        || p.ends_with(".sass")
+        || p.ends_with(".less")
+        || p.contains("_tokens.")
+        || p.contains("_mixins.")
+        || p.contains("tokens.scss")
+        || p.contains("mixins.scss")
+}
+
+pub(crate) fn inject_style_seeds(
+    graph: &NeuralProjectGraph,
+    prompt: &str,
+    signature: &TaskSignature,
+    sink: &mut SeedSink<'_>,
+) {
+    if !is_style_task(signature) {
+        return;
+    }
+
+    let style_ext = signature.style.as_deref().map(|s| s.to_ascii_lowercase());
+    for hint in style_file_hints(&style_ext) {
+        if let Some(id) = graph.resolve_file_hint(hint) {
+            sink.push(graph, prompt, hint.to_string(), 0.95, "style_hint");
+            let _ = id;
+        }
+    }
+
+    let lower = signature.raw_prompt.to_lowercase();
+    if lower.contains("productcard")
+        || lower.contains("product card")
+        || lower.contains("price-card")
+    {
+        sink.push(graph, prompt, "ProductCard".into(), 0.9, "style_component");
+    }
+}
+
+fn style_file_hints(style: &Option<String>) -> Vec<&'static str> {
+    match style.as_deref() {
+        Some("scss") | Some("sass") => vec![
+            "src/styles/_tokens.scss",
+            "src/styles/tokens.scss",
+            "src/styles/_mixins.scss",
+            "src/styles/mixins.scss",
+            "styles/_tokens.scss",
+            "styles/_mixins.scss",
+        ],
+        Some("less") => vec!["styles/tokens.less", "src/styles/tokens.less"],
+        Some("css") => vec!["styles/tokens.css", "src/styles/tokens.css"],
+        _ => vec![
+            "src/styles/_tokens.scss",
+            "src/styles/_mixins.scss",
+            "styles/_tokens.scss",
+            "styles/_mixins.scss",
+        ],
+    }
+}
+
+pub(crate) fn inject_view_component_seeds(
+    graph: &NeuralProjectGraph,
+    prompt: &str,
+    signature: &TaskSignature,
+    sink: &mut SeedSink<'_>,
+) {
+    let lower = signature.raw_prompt.to_lowercase();
+    if !lower.contains("checkout")
+        && !lower.contains("cartview")
+        && !lower.contains("productcard")
+        && !lower.contains("product card")
+    {
+        return;
+    }
+    let mut candidates: HashSet<String> = HashSet::new();
+    for ident in &signature.identifiers {
+        if ident.ends_with("View") || ident.ends_with("Component") {
+            candidates.insert(ident.clone());
+        }
+    }
+    for word in ["checkout", "cart", "product", "home", "header"] {
+        if lower.contains(word) {
+            candidates.insert(format!("{}View", pascal_case(word)));
+        }
+    }
+    for name in candidates {
+        if name.len() < 5 {
+            continue;
+        }
+        sink.push(graph, prompt, name, 0.82, "view_component");
+    }
+}
+
+pub fn style_noise_penalty(path: &std::path::Path, signature: &TaskSignature) -> f32 {
+    if !is_style_task(signature) {
+        return 0.0;
+    }
+    let p = path.to_string_lossy().replace('\\', "/").to_lowercase();
+    if is_style_path(path) {
+        return 0.0;
+    }
+    if p.contains("promo")
+        || p.contains("cartdrawer")
+        || p.contains("cartview")
+        || p.contains("/stores/cart")
+    {
+        return 28.0;
+    }
+    0.0
+}
+
+fn pascal_case(raw: &str) -> String {
+    let clean: String = raw.chars().filter(|c| c.is_alphanumeric()).collect();
+    if clean.is_empty() {
+        return String::new();
+    }
+    let mut chars = clean.chars();
+    let first = chars.next().unwrap().to_ascii_uppercase();
+    let rest: String = chars.flat_map(|c| c.to_lowercase()).collect();
+    format!("{first}{rest}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_style_task_from_tokens_keyword() {
+        let sig = TaskSignature {
+            id: "t".into(),
+            intent: neuromesh_core::TaskIntent::Modify,
+            domain: "frontend".into(),
+            technology: "Vue".into(),
+            style: None,
+            entity: "ProductCard".into(),
+            goal: "style".into(),
+            risk: neuromesh_core::TaskRisk::Low,
+            related_concepts: vec![],
+            identifiers: vec!["ProductCard".into()],
+            file_hints: vec![],
+            confidence: 0.9,
+            raw_prompt: "Apply hover-lift using SCSS tokens and mixins on ProductCard".into(),
+        };
+        assert!(is_style_task(&sig));
+    }
+
+    #[test]
+    fn pascal_case_handles_checkout() {
+        assert_eq!(pascal_case("checkout"), "Checkout");
+    }
+}

--- a/crates/neuromesh-core/src/lib.rs
+++ b/crates/neuromesh-core/src/lib.rs
@@ -30,5 +30,5 @@ pub use types::{
     ActivatedNodeView, ContextDiff, ContextEdge, ContextNode, ContextStatus, ContextView,
     CoverageReport, EdgeConfidence, EdgeId, EdgeType, InactiveContextDescriptor, IndexMeta,
     NextAction, NodeId, NodeType, OptimizationMetadata, PacketGap, ProjectId, SeedResolution,
-    StructuralEvidence, UnresolvedRef,
+    SkippedFile, StructuralEvidence, UnresolvedRef,
 };

--- a/crates/neuromesh-core/src/lib.rs
+++ b/crates/neuromesh-core/src/lib.rs
@@ -29,5 +29,6 @@ pub use token::TokenCounter;
 pub use types::{
     ActivatedNodeView, ContextDiff, ContextEdge, ContextNode, ContextStatus, ContextView,
     CoverageReport, EdgeConfidence, EdgeId, EdgeType, InactiveContextDescriptor, IndexMeta,
-    NextAction, NodeId, NodeType, OptimizationMetadata, ProjectId, SeedResolution, UnresolvedRef,
+    NextAction, NodeId, NodeType, OptimizationMetadata, PacketGap, ProjectId, SeedResolution,
+    StructuralEvidence, UnresolvedRef,
 };

--- a/crates/neuromesh-core/src/types.rs
+++ b/crates/neuromesh-core/src/types.rs
@@ -230,16 +230,46 @@ pub struct SeedResolution {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PacketGap {
+    pub kind: String,
+    pub path: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StructuralEvidence {
+    pub symbol: String,
+    pub path: String,
+    pub line: Option<usize>,
+    pub callers_count: usize,
+    pub is_dead: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CoverageReport {
     pub seeds_hit: Vec<String>,
     pub seeds_missed: Vec<String>,
     pub claim: String,
+    /// Files the task likely needs but that are not in the packet.
+    #[serde(default)]
+    pub packet_gaps: Vec<PacketGap>,
+    /// Near-miss files worth expanding before Grep.
+    #[serde(default)]
+    pub unsure: Vec<String>,
 }
 
 impl CoverageReport {
-    /// `no_recorded_gap` only when every *attempted* seed resolved.
+    /// `no_recorded_gap` only when every *attempted* seed resolved and packet gaps are empty.
     /// `unresolved` on the packet is graph call/import gaps, not this list.
     pub fn from_seeds(seeds: &[SeedResolution]) -> Self {
+        Self::from_seeds_with_gaps(seeds, Vec::new(), Vec::new())
+    }
+
+    pub fn from_seeds_with_gaps(
+        seeds: &[SeedResolution],
+        packet_gaps: Vec<PacketGap>,
+        unsure: Vec<String>,
+    ) -> Self {
         let seeds_hit: Vec<String> = seeds
             .iter()
             .filter(|s| s.resolved_id.is_some())
@@ -250,10 +280,10 @@ impl CoverageReport {
             .filter(|s| s.resolved_id.is_none())
             .map(|s| s.query.clone())
             .collect();
-        let claim = if seeds.is_empty() || seeds_missed.is_empty() {
-            "no_recorded_gap".to_string()
-        } else if seeds_hit.is_empty() {
+        let claim = if seeds_hit.is_empty() {
             "no_seed_resolved".to_string()
+        } else if seeds_missed.is_empty() && packet_gaps.is_empty() {
+            "no_recorded_gap".to_string()
         } else {
             "partial".to_string()
         };
@@ -261,6 +291,8 @@ impl CoverageReport {
             seeds_hit,
             seeds_missed,
             claim,
+            packet_gaps,
+            unsure,
         }
     }
 }
@@ -366,6 +398,9 @@ pub struct ContextView {
     /// `seed_then_fill` or `physarum_seed_fill`.
     #[serde(default)]
     pub selection_method: String,
+    /// Caller counts / dead-code hints for seeded symbols.
+    #[serde(default)]
+    pub structural_evidence: Vec<StructuralEvidence>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/neuromesh-core/src/types.rs
+++ b/crates/neuromesh-core/src/types.rs
@@ -234,6 +234,14 @@ pub struct PacketGap {
     pub kind: String,
     pub path: String,
     pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkippedFile {
+    pub path: String,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -241,8 +249,12 @@ pub struct StructuralEvidence {
     pub symbol: String,
     pub path: String,
     pub line: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exact_line: Option<String>,
     pub callers_count: usize,
     pub is_dead: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub who_reads: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -256,19 +268,31 @@ pub struct CoverageReport {
     /// Near-miss files worth expanding before Grep.
     #[serde(default)]
     pub unsure: Vec<String>,
+    /// Files included in this packet.
+    #[serde(default)]
+    pub covered: Vec<String>,
+    /// Files intentionally excluded (noise filter, budget, parse partial).
+    #[serde(default)]
+    pub skipped: Vec<SkippedFile>,
+    /// For style tasks: share of packet files under styles/ (0.0–1.0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_coverage: Option<f32>,
 }
 
 impl CoverageReport {
     /// `no_recorded_gap` only when every *attempted* seed resolved and packet gaps are empty.
     /// `unresolved` on the packet is graph call/import gaps, not this list.
     pub fn from_seeds(seeds: &[SeedResolution]) -> Self {
-        Self::from_seeds_with_gaps(seeds, Vec::new(), Vec::new())
+        Self::from_seeds_with_gaps(seeds, Vec::new(), Vec::new(), Vec::new(), Vec::new(), None)
     }
 
     pub fn from_seeds_with_gaps(
         seeds: &[SeedResolution],
         packet_gaps: Vec<PacketGap>,
         unsure: Vec<String>,
+        covered: Vec<String>,
+        skipped: Vec<SkippedFile>,
+        semantic_coverage: Option<f32>,
     ) -> Self {
         let seeds_hit: Vec<String> = seeds
             .iter()
@@ -293,6 +317,9 @@ impl CoverageReport {
             claim,
             packet_gaps,
             unsure,
+            covered,
+            skipped,
+            semantic_coverage,
         }
     }
 }

--- a/crates/neuromesh-graph/src/graph.rs
+++ b/crates/neuromesh-graph/src/graph.rs
@@ -47,6 +47,27 @@ pub struct GraphStats {
     pub generation: u64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeighborLearningWeight {
+    pub node_id: String,
+    pub name: String,
+    pub path: String,
+    pub edge_type: String,
+    pub pheromone_weight: f32,
+    pub reinforcement_count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeLearningProfile {
+    pub node_id: String,
+    pub name: String,
+    pub path: String,
+    pub access_count: u64,
+    pub base_relevance: f32,
+    pub learning_bonus: f32,
+    pub neighbors: Vec<NeighborLearningWeight>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IndexState {
@@ -2027,6 +2048,62 @@ impl NeuralProjectGraph {
             node.base_relevance = (node.base_relevance - 0.12).max(0.1);
         }
         node.base_relevance - before
+    }
+
+    /// Observable learning state for a symbol/path (falsifiable feedback checks).
+    pub fn node_learning_profile(&self, query: &str) -> Option<NodeLearningProfile> {
+        let node = self.resolve_feedback_node(query)?;
+        let bonus = learning_bonus(&node);
+        let neighbors: Vec<NeighborLearningWeight> = self
+            .get_connected_neighbors(&node.id)
+            .into_iter()
+            .take(12)
+            .filter_map(|(neighbor_id, edge)| {
+                let neighbor = self.get_node(&neighbor_id)?;
+                Some(NeighborLearningWeight {
+                    node_id: neighbor_id.as_str().to_string(),
+                    name: neighbor.name.clone(),
+                    path: neighbor.file_path.to_string_lossy().replace('\\', "/"),
+                    edge_type: format!("{:?}", edge.edge_type),
+                    pheromone_weight: edge.pheromone_weight,
+                    reinforcement_count: edge.reinforcement_count,
+                })
+            })
+            .collect();
+        Some(NodeLearningProfile {
+            node_id: node.id.as_str().to_string(),
+            name: node.name.clone(),
+            path: node.file_path.to_string_lossy().replace('\\', "/"),
+            access_count: node.access_count,
+            base_relevance: node.base_relevance,
+            learning_bonus: bonus,
+            neighbors,
+        })
+    }
+
+    /// Reinforce 1-hop call/import edges around touched nodes so related files enter packets.
+    pub fn reinforce_callee_edges(&self, node_ids: &[NodeId], success: bool) {
+        let mut edge_ids: HashSet<EdgeId> = HashSet::new();
+        for id in node_ids {
+            for (_, edge) in self.get_connected_neighbors(id) {
+                if matches!(
+                    edge.edge_type,
+                    EdgeType::Calls | EdgeType::Imports | EdgeType::References | EdgeType::UsedBy
+                ) {
+                    edge_ids.insert(edge.id.clone());
+                }
+            }
+        }
+        let mut data = self.inner.write();
+        for edge_id in edge_ids {
+            if let Some(edge) = data.mesh.edge_mut(&edge_id) {
+                if success {
+                    self.pheromone_engine.reinforce_success(edge, 1);
+                } else {
+                    self.pheromone_engine.penalize_failure(edge);
+                }
+            }
+        }
     }
 
     /// Count inbound call/import edges to a symbol (for dead-code evidence).

--- a/crates/neuromesh-graph/src/graph.rs
+++ b/crates/neuromesh-graph/src/graph.rs
@@ -12,6 +12,7 @@ use crate::query::{
     NeighborView, SearchHit, TraceDirection, TraceHop, TraceResult,
 };
 use crate::synapse::{StdpConfig, SynapticPlasticityEngine};
+use chrono::Utc;
 use neuromesh_core::{
     hmvc_app_prefix, is_core_source_path, is_json_schema_path, is_low_priority_source_path,
     is_name_collision_decoy, name_match_specificity, ContextEdge, ContextNode, EdgeConfidence,
@@ -1999,6 +2000,62 @@ impl NeuralProjectGraph {
             .record_spike(node_id, was_modified, was_useful);
     }
 
+    /// Resolve human-friendly node names (`CheckoutView`, paths, sym ids) to graph nodes.
+    pub fn resolve_feedback_node(&self, query: &str) -> Option<ContextNode> {
+        let trimmed = query.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if let Some(node) = self.get_node(&NodeId::new(trimmed)) {
+            return Some(node);
+        }
+        self.resolve_best(trimmed)
+    }
+
+    /// Bump per-node learning signals so the next search/packet can prefer touched symbols.
+    pub fn reinforce_node_access(&self, node_id: &NodeId, success: bool) -> f32 {
+        let mut data = self.inner.write();
+        let Some(node) = data.mesh.node_mut(node_id) else {
+            return 0.0;
+        };
+        let before = node.base_relevance;
+        node.access_count = node.access_count.saturating_add(1);
+        node.last_accessed = Utc::now();
+        if success {
+            node.base_relevance = (node.base_relevance + 0.08).min(3.0);
+        } else {
+            node.base_relevance = (node.base_relevance - 0.12).max(0.1);
+        }
+        node.base_relevance - before
+    }
+
+    /// Count inbound call/import edges to a symbol (for dead-code evidence).
+    pub fn inbound_caller_count(&self, node_id: &NodeId) -> usize {
+        self.get_connected_neighbors(node_id)
+            .into_iter()
+            .filter(|(_, edge)| {
+                edge.target == *node_id
+                    && matches!(
+                        edge.edge_type,
+                        EdgeType::Calls | EdgeType::UsedBy | EdgeType::References
+                    )
+            })
+            .count()
+    }
+
+    pub fn is_likely_dead_symbol(&self, node_id: &NodeId) -> bool {
+        let Some(node) = self.get_node(node_id) else {
+            return false;
+        };
+        if !matches!(
+            node.node_type,
+            NodeType::Function | NodeType::Symbol | NodeType::Api
+        ) {
+            return false;
+        }
+        self.inbound_caller_count(node_id) == 0
+    }
+
     /// Applies STDP only on edges whose endpoints have recorded spikes.
     pub fn apply_stdp_learning(&self) {
         let spiked: HashSet<NodeId> = {
@@ -2104,6 +2161,12 @@ fn type_search_rank(node_type: &NodeType) -> u8 {
     }
 }
 
+fn learning_bonus(node: &ContextNode) -> f32 {
+    let access = (node.access_count as f32).ln_1p() * 5.0;
+    let relevance = (node.base_relevance - 1.0).max(0.0) * 10.0;
+    access + relevance
+}
+
 fn ranking_bonus(node: &ContextNode, query: &str) -> f32 {
     let mut bonus = match node.node_type {
         NodeType::Function
@@ -2146,6 +2209,7 @@ fn ranking_bonus(node: &ContextNode, query: &str) -> f32 {
     if is_fixture_path(&node.file_path) {
         bonus -= if decoy { 40.0 } else { 24.0 };
     }
+    bonus += learning_bonus(node);
     bonus
 }
 

--- a/crates/neuromesh-graph/src/lib.rs
+++ b/crates/neuromesh-graph/src/lib.rs
@@ -15,7 +15,9 @@ mod repo_quality_tests;
 
 pub use activation::{SpreadingActivation, SpreadingActivationConfig};
 pub use edge::{PheromoneConfig, PheromoneEngine};
-pub use graph::{path_echoes_symbol, GraphStats, IndexState, NeuralProjectGraph};
+pub use graph::{
+    path_echoes_symbol, GraphStats, IndexState, NeuralProjectGraph, NodeLearningProfile,
+};
 pub use node::NodeFactory;
 pub use physarum::{PhysarumConfig, PhysarumResult, PhysarumSolver};
 pub use query::{

--- a/crates/neuromesh-mcp/src/descriptors.rs
+++ b/crates/neuromesh-mcp/src/descriptors.rs
@@ -35,7 +35,7 @@ pub fn tools_list() -> Vec<Value> {
         tool(
             "neuromesh_get_context",
             "Get evidence packet",
-            "Return a compact evidence packet by default: packet_id, coverage (no_recorded_gap|partial|no_seed_resolved), selected/packet tokens, skeletonized files, fold ids without bodies, and missing seeds only when coverage is incomplete. mode controls file selection quality; response_detail controls metadata. Pass diagnostic on-demand via neuromesh_explain_packet. Never treats silence as completeness. Compound tasks seed each topical cluster independently; a named cluster with zero hits is partial, not no_recorded_gap. no_seed_resolved means every identifier missed — Grep immediately. Pass the user prompt as task_description, prompt, or task.",
+            "Return a compact evidence packet by default: packet_id, coverage (claim, covered, skipped, unsure, packet_gaps; no_recorded_gap only when seeds and gaps are empty), selected/packet tokens, skeletonized files, fold ids without bodies, and missing seeds only when coverage is incomplete. mode controls file selection quality; response_detail controls metadata. Pass diagnostic on-demand via neuromesh_explain_packet. Never treats silence as completeness. Compound tasks seed each topical cluster independently; a named cluster with zero hits is partial, not no_recorded_gap. no_seed_resolved means every identifier missed — Grep immediately. Pass the user prompt as task_description, prompt, or task.",
             json!({
                 "type": "object",
                 "properties": {
@@ -257,6 +257,34 @@ pub fn tools_list() -> Vec<Value> {
             "Project memory",
             "Retrieve project architectural rules, tech stack decisions, and framework conventions.",
             json!({ "type": "object", "properties": {} }),
+            read_only(),
+        ),
+        tool(
+            "neuromesh_get_node_weights",
+            "Node learning weights",
+            "Read access_count, base_relevance, learning_bonus, and neighbor pheromone weights for a symbol or path. Use before/after record_feedback to verify learning.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string", "description": "Symbol name or file path" },
+                    "symbol": { "type": "string", "description": "Alias for query" },
+                    "path": { "type": "string", "description": "Alias for query" }
+                }
+            }),
+            read_only(),
+        ),
+        tool(
+            "neuromesh_expand_gap",
+            "Expand packet gap",
+            "Cheap skeleton for a path listed in packet_gaps or unsure — avoids blind Grep when coverage is partial.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "Relative file path from packet_gaps" },
+                    "file_path": { "type": "string", "description": "Alias for path" },
+                    "token_cap": { "type": "integer", "description": "Max skeleton tokens (default 200)" }
+                }
+            }),
             read_only(),
         ),
         tool(

--- a/crates/neuromesh-mcp/src/protocol.rs
+++ b/crates/neuromesh-mcp/src/protocol.rs
@@ -103,6 +103,8 @@ pub fn canonical_tool_name(name: &str) -> String {
         "get_architecture" | "architecture" => "neuromesh_get_architecture".into(),
         "get_project_memory" | "project_memory" | "memory" => "neuromesh_get_project_memory".into(),
         "get_stats" | "stats" => "neuromesh_get_stats".into(),
+        "get_node_weights" | "node_weights" | "weights" => "neuromesh_get_node_weights".into(),
+        "expand_gap" | "gap" => "neuromesh_expand_gap".into(),
         "explain_packet" | "get_context_details" => "neuromesh_explain_packet".into(),
         _ if trimmed.starts_with("neuromesh_") => trimmed.to_string(),
         _ => trimmed.to_string(),

--- a/crates/neuromesh-mcp/src/response.rs
+++ b/crates/neuromesh-mcp/src/response.rs
@@ -354,6 +354,9 @@ impl ContextBuild<'_> {
         if !self.view.next_actions.is_empty() {
             packet["next_actions"] = json!(self.view.next_actions);
         }
+        if !self.view.structural_evidence.is_empty() {
+            packet["structural_evidence"] = json!(self.view.structural_evidence);
+        }
         json!({
             "packet_id": self.packet_id,
             "task": {

--- a/crates/neuromesh-mcp/src/tools.rs
+++ b/crates/neuromesh-mcp/src/tools.rs
@@ -187,6 +187,22 @@ impl McpToolHandler {
                 let detail = ResponseDetail::parse(arguments["response_detail"].as_str());
 
                 let signature = TaskSignatureExtractor::extract(&task_desc);
+                let mut signature = signature;
+                if let Ok(episodes) = self
+                    .memory_db
+                    .find_similar_episodes(&self.graph.project_id(), &task_desc)
+                {
+                    for ep in episodes.into_iter().filter(|e| e.success).take(3) {
+                        for name in &ep.successful_path {
+                            if name.len() < 3 {
+                                continue;
+                            }
+                            if !signature.identifiers.iter().any(|i| i == name) {
+                                signature.identifiers.push(name.clone());
+                            }
+                        }
+                    }
+                }
                 let gate = QualityGate::evaluate(&signature, requested_mode);
                 let view = self
                     .activator
@@ -257,6 +273,55 @@ impl McpToolHandler {
                     &build,
                     detail,
                 ))
+            }
+
+            // 2b. Expand a packet gap file (cheap skeleton, no blind Grep)
+            "neuromesh_expand_gap" => {
+                let start_time = std::time::Instant::now();
+                let file_path = arguments["path"]
+                    .as_str()
+                    .or_else(|| arguments["file_path"].as_str())
+                    .unwrap_or("");
+                if file_path.is_empty() {
+                    return Ok(json!({
+                        "success": false,
+                        "error": "path is required (from packet_gaps or unsure)"
+                    }));
+                }
+                let node_id = NodeId::from_file_path(file_path);
+                let content_opt = self
+                    .graph
+                    .get_node(&node_id)
+                    .and_then(|n| self.graph.read_source(&n.file_path));
+                let content_opt = match content_opt {
+                    Some(content) => Some(content),
+                    None => match self.read_workspace_source(file_path) {
+                        Ok(content) => content,
+                        Err(err) => return Ok(json!({ "success": false, "error": err })),
+                    },
+                };
+                if let Some(content) = content_opt {
+                    let res = CodeSkeletonizer::skeletonize(file_path, &content, &HashSet::new());
+                    let cap = arguments["token_cap"].as_u64().unwrap_or(200) as usize;
+                    let skeleton = if res.skeleton_tokens > cap {
+                        res.skeleton_code
+                            .lines()
+                            .take(40)
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    } else {
+                        res.skeleton_code
+                    };
+                    Ok(json!({
+                        "success": true,
+                        "path": file_path,
+                        "skeleton": skeleton,
+                        "skeleton_tokens": res.skeleton_tokens.min(cap),
+                        "latency_ms": start_time.elapsed().as_millis(),
+                    }))
+                } else {
+                    Ok(json!({ "success": false, "error": "file not found" }))
+                }
             }
 
             // 2. Get File Skeleton with Folded Introns
@@ -599,6 +664,7 @@ impl McpToolHandler {
                 }
                 self.graph.apply_stdp_on_path(&path);
                 self.graph.reinforce_path(&path, success);
+                self.graph.reinforce_callee_edges(&path, success);
                 self.record_mycelium_path(&path);
                 if let Ok(cwd) = std::env::current_dir() {
                     let _ = self.graph.save_persisted(&cwd);
@@ -696,6 +762,33 @@ impl McpToolHandler {
                     ..ToolTelemetry::new("mcp-wm", "Task state", "get_task_state")
                 });
                 Ok(json!({ "working_memory": wm }))
+            }
+
+            // 9b. Read per-node learning weights (falsifiable feedback observability)
+            "neuromesh_get_node_weights" => {
+                let start_time = std::time::Instant::now();
+                let query = arguments["query"]
+                    .as_str()
+                    .or_else(|| arguments["symbol"].as_str())
+                    .or_else(|| arguments["path"].as_str())
+                    .unwrap_or("");
+                if query.is_empty() {
+                    return Ok(json!({
+                        "error": "query, symbol, or path is required"
+                    }));
+                }
+                match self.graph.node_learning_profile(query) {
+                    Some(profile) => {
+                        self.emit_telemetry(ToolTelemetry {
+                            latency_ms: start_time.elapsed().as_millis() as u64,
+                            ..ToolTelemetry::new("mcp-weights", query, "get_node_weights")
+                        });
+                        Ok(json!(profile))
+                    }
+                    None => Ok(json!({
+                        "error": format!("node not found for query: {query}")
+                    })),
+                }
             }
 
             // 10. Get System Stats & Biomimetic Health

--- a/crates/neuromesh-mcp/src/tools.rs
+++ b/crates/neuromesh-mcp/src/tools.rs
@@ -568,17 +568,60 @@ impl McpToolHandler {
                 let touched_nodes = read_string_list(arguments, "touched_nodes");
 
                 let mut path: Vec<NodeId> = Vec::new();
+                let mut resolved: Vec<Value> = Vec::new();
+                let mut weight_deltas: Vec<Value> = Vec::new();
                 for node_name in &touched_nodes {
-                    let node_id = NodeId::new(node_name);
+                    let Some(node) = self.graph.resolve_feedback_node(node_name) else {
+                        resolved.push(json!({
+                            "query": node_name,
+                            "resolved": false
+                        }));
+                        continue;
+                    };
+                    let delta = self.graph.reinforce_node_access(&node.id, success);
                     self.graph
-                        .record_neural_spike(node_id.clone(), true, success);
-                    path.push(node_id);
+                        .record_neural_spike(node.id.clone(), true, success);
+                    path.push(node.id.clone());
+                    resolved.push(json!({
+                        "query": node_name,
+                        "resolved": true,
+                        "node_id": node.id.as_str(),
+                        "name": node.name,
+                        "path": node.file_path.to_string_lossy().replace('\\', "/"),
+                        "relevance_delta": delta,
+                        "access_count": node.access_count.saturating_add(1),
+                        "base_relevance": (node.base_relevance + delta).min(3.0)
+                    }));
+                    weight_deltas.push(json!({
+                        "node_id": node.id.as_str(),
+                        "relevance_delta": delta
+                    }));
                 }
                 self.graph.apply_stdp_on_path(&path);
                 self.graph.reinforce_path(&path, success);
                 self.record_mycelium_path(&path);
                 if let Ok(cwd) = std::env::current_dir() {
                     let _ = self.graph.save_persisted(&cwd);
+                }
+
+                let pid = self.graph.project_id();
+                if !path.is_empty() {
+                    let summary = if success {
+                        format!("successful edit touching {}", path.len())
+                    } else {
+                        format!("failed attempt touching {}", path.len())
+                    };
+                    let episode = neuromesh_memory::EpisodicRecord::new(
+                        pid.clone(),
+                        format!("feedback:{summary}"),
+                        if success { "success" } else { "failure" }.into(),
+                        summary,
+                        path.clone(),
+                        touched_nodes.clone(),
+                        success,
+                        0,
+                    );
+                    let _ = self.memory_db.save_episodic_record(&episode);
                 }
 
                 self.emit_telemetry(ToolTelemetry {
@@ -595,6 +638,9 @@ impl McpToolHandler {
                     "success": success,
                     "stdp_learning_applied": true,
                     "path_nodes": path.len(),
+                    "resolved_nodes": resolved,
+                    "weight_deltas": weight_deltas,
+                    "episodes_recorded": if path.is_empty() { 0 } else { 1 },
                     "updated_graph_stats": self.graph.stats()
                 }))
             }

--- a/crates/neuromesh-parser/src/vue.rs
+++ b/crates/neuromesh-parser/src/vue.rs
@@ -1,6 +1,7 @@
 use crate::types::{AstAnalysisResult, ParsedImport, ParsedRelationship, ParsedSymbol};
 use neuromesh_core::{EdgeType, NodeType};
 use regex::Regex;
+use std::collections::HashMap;
 use std::path::Path;
 
 pub struct VueParser;
@@ -128,6 +129,36 @@ impl VueParser {
                     }
                 }
             }
+        }
+
+        // 4b. Template handlers (@click="ui.goCart()") -> store action calls
+        let mut store_aliases: HashMap<String, String> = HashMap::new();
+        let alias_store_regex = Regex::new(r"const\s+(\w+)\s*=\s*(use\w+Store)\s*\(").unwrap();
+        for cap in alias_store_regex.captures_iter(content) {
+            if let (Some(alias), Some(hook)) = (cap.get(1), cap.get(2)) {
+                store_aliases.insert(alias.as_str().to_string(), pinia_store_hint(hook.as_str()));
+            }
+        }
+        let handler_regex =
+            Regex::new(r#"(?:@click|@submit|v-on:click|v-on:submit)\s*=\s*["']([^"']+)["']"#)
+                .unwrap();
+        let action_call_regex = Regex::new(r"(\w+)\.(\w+)\s*\(").unwrap();
+        for cap in handler_regex.captures_iter(content) {
+            let Some(expr) = cap.get(1) else {
+                continue;
+            };
+            let Some(am) = action_call_regex.captures(expr.as_str()) else {
+                continue;
+            };
+            let alias = am.get(1).map(|m| m.as_str()).unwrap_or("");
+            let action = am.get(2).map(|m| m.as_str()).unwrap_or("");
+            result.relationships.push(ParsedRelationship {
+                source_symbol: filename.to_string(),
+                target_symbol: action.to_string(),
+                relationship: EdgeType::Calls,
+                target_file_hint: store_aliases.get(alias).cloned(),
+                receiver_hint: Some(alias.to_string()),
+            });
         }
 
         // 5. Extract SCSS @use / @import / Design tokens from <style>
@@ -309,4 +340,30 @@ fn is_native_html_tag(tag: &str) -> bool {
             | "video"
             | "wbr"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_click_extracts_store_action_call() {
+        let src = r#"<script setup>
+const ui = useUiStore()
+</script>
+<template>
+  <button @click="ui.goCart()">Cart</button>
+</template>
+"#;
+        let ast = VueParser::parse(std::path::Path::new("Header.vue"), src);
+        assert!(
+            ast.relationships.iter().any(|r| {
+                r.target_symbol == "goCart"
+                    && r.relationship == EdgeType::Calls
+                    && r.target_file_hint.as_deref() == Some("stores/ui.ts")
+            }),
+            "expected goCart call edge, rels={:?}",
+            ast.relationships
+        );
+    }
 }

--- a/crates/neuromesh-task/src/signature.rs
+++ b/crates/neuromesh-task/src/signature.rs
@@ -163,6 +163,18 @@ impl TaskSignatureExtractor {
         if lower.contains("state") || lower.contains("pinia") || lower.contains("store") {
             related_concepts.push("state".to_string());
         }
+        if (lower.contains("token") || lower.contains("mixin") || lower.contains("stylesheet"))
+            && (lower.contains("scss")
+                || lower.contains("sass")
+                || lower.contains("stylesheet")
+                || lower.contains("mixin"))
+        {
+            related_concepts.push("tokens".to_string());
+            related_concepts.push("mixins".to_string());
+        }
+        if lower.contains("checkout") {
+            related_concepts.push("CheckoutView".to_string());
+        }
 
         related_concepts.sort();
         related_concepts.dedup();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable user-facing changes live here. The README stays a product guide, not
 
 ## Unreleased
 
+## 0.7.7 — 2026-08-28
+
+Benchmark-driven routing, honest coverage, and a falsifiable learning loop (Vue shop fixture).
+
+- **Shop gold fixture.** `tests/fixtures/mini-shop/` (Vue 3 + Pinia + SCSS) with gold tasks for price-card SCSS (T6), dead-code `goCart` (T7), and checkout `setQty` (T5). Runs in `gold_harness_on_fixture_repos`.
+- **Style routing.** Unified SCSS file hints (`tokens.scss` / `mixins.scss` with and without `_`), `_priceCard.scss` seeds, StyleToken search seeds, and cart/promo noise filtering so style tasks do not ship cart components.
+- **View seeds.** `related_concepts` become seeds; checkout/stepper prompts inject `CheckoutView` without `checkout` ⊃ `cart` false positives; focused checkout tasks tighten optional fill.
+- **Coverage honesty.** `CoverageReport` adds `covered`, `skipped`, `semantic_coverage`, and `packet_gaps` (with optional `line`). `no_recorded_gap` only when seeds and packet gaps are both empty.
+- **Structural proof.** `structural_evidence` includes `exact_line`, `who_reads`, `callers_count`, and `is_dead`; bug-hunt tasks can emit `bug_line` gaps (e.g. duplicate discount in `total()`).
+- **Vue template → store.** `@click` / `@submit` handlers (`ui.goCart()`) emit `Calls` edges to Pinia actions for dead-code and caller tracing.
+- **Learning loop.** `record_feedback` resolves human names, persists `base_relevance` to `graph.bin`, saves episodes, reinforces callee edges, and recalls successful episodes on the next `get_context`. `neuromesh_get_node_weights` exposes deltas for verification.
+- **New MCP tools.** `neuromesh_expand_gap` (cheap skeleton for gap paths) and `neuromesh_get_node_weights` (observability).
+- **Selector / skeleton.** `learning_bonus` boosts file fill from `access_count` / `base_relevance`; files ≤60 lines fold more aggressively.
+- **Docs / ops.** README and [mcp.md](mcp.md) warn against `mcp` without a workspace path; [mcp.md](mcp.md) documents learning timing and new tools.
+
 ## 0.7.6 — 2026-08-27
 
 Agent setup guide, HTTP route seeds, Pinx/Vue overlays, Laravel/SQL/JSON, and tighter TS seed ranking.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -25,12 +25,12 @@ This workspace has the NeuroMesh MCP server. Prefer it for **reading and explori
 ## Default loop
 
 1. Start with `neuromesh_get_context` using the task as written (`task_description` / `prompt` / `task`).
-2. If `coverage` is `partial` or `no_seed_resolved`, follow `missing` / `next` — usually `neuromesh_search_symbols` — before broad Grep.
-3. Expand only what you need: `neuromesh_expand_fold` with a `fold_id` from the packet (or `neuromesh_get_file_skeleton` for one path).
+2. If `coverage.claim` is `partial` or `no_seed_resolved`, follow `packet_gaps` / `next` — `neuromesh_expand_gap` for near-miss paths, or `neuromesh_search_symbols` before broad Grep.
+3. Expand only what you need: `neuromesh_expand_fold` with a `fold_id` from the packet (or `neuromesh_get_file_skeleton` / `neuromesh_expand_gap` for one path).
 4. Use `neuromesh_trace` / `neuromesh_get_dependencies` / `neuromesh_analyze_impact` for callers, neighbors, and blast radius.
-5. After a successful edit, call `neuromesh_record_feedback` with `task_success` and the nodes you touched.
+5. After a successful edit, call `neuromesh_record_feedback` with `task_success` and the nodes you touched. Use `neuromesh_get_node_weights` before/after to verify learning deltas when debugging routing.
 
-Do not treat a utility fallback file as the answer when coverage says seeds missed.
+Do not treat a utility fallback file as the answer when coverage says seeds missed or `packet_gaps` is non-empty.
 
 ## When not to force NeuroMesh
 

--- a/docs/agent-rule.mdc
+++ b/docs/agent-rule.mdc
@@ -12,12 +12,12 @@ This workspace has the NeuroMesh MCP server. Prefer it for **reading and explori
 ## Default loop
 
 1. Start with `neuromesh_get_context` using the task as written (`task_description` / `prompt` / `task`).
-2. If `coverage` is `partial` or `no_seed_resolved`, follow `missing` / `next` — usually `neuromesh_search_symbols` — before broad Grep.
-3. Expand only what you need: `neuromesh_expand_fold` with a `fold_id` from the packet (or `neuromesh_get_file_skeleton` for one path).
+2. If `coverage.claim` is `partial` or `no_seed_resolved`, follow `packet_gaps` / `next` — `neuromesh_expand_gap` for near-miss paths, or `neuromesh_search_symbols` before broad Grep.
+3. Expand only what you need: `neuromesh_expand_fold` with a `fold_id` from the packet (or `neuromesh_get_file_skeleton` / `neuromesh_expand_gap` for one path).
 4. Use `neuromesh_trace` / `neuromesh_get_dependencies` / `neuromesh_analyze_impact` for callers, neighbors, and blast radius.
-5. After a successful edit, call `neuromesh_record_feedback` with `task_success` and the nodes you touched.
+5. After a successful edit, call `neuromesh_record_feedback` with `task_success` and the nodes you touched. Use `neuromesh_get_node_weights` before/after to verify learning deltas when debugging routing.
 
-Do not treat a utility fallback file as the answer when coverage says seeds missed.
+Do not treat a utility fallback file as the answer when coverage says seeds missed or `packet_gaps` is non-empty.
 
 ## When not to force NeuroMesh
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,8 @@
 # MCP tools
 
-Transport: **stdio JSON-RPC** (`neuromesh mcp`). That is what Cursor, Claude, Codex, Antigravity, Kilo Code, Trae, Cline, and similar clients launch. Stdio has **no TCP port** — `--port` on `mcp` does nothing. Background index uses the same file-cap rules as `neuromesh index` (`--max-files`, `NEUROMESH_MAX_FILES`, project-slot `config.json`; default auto, ceiling 50,000). See [cli.md](cli.md#index-file-cap).
+Transport: **stdio JSON-RPC** (`neuromesh mcp <workspace>`). That is what Cursor, Claude, Codex, Antigravity, Kilo Code, Trae, Cline, and similar clients launch. Stdio has **no TCP port** — `--port` on `mcp` does nothing. Background index uses the same file-cap rules as `neuromesh index` (`--max-files`, `NEUROMESH_MAX_FILES`, project-slot `config.json`; default auto, ceiling 50,000). See [cli.md](cli.md#index-file-cap).
+
+**Warning:** Never run `neuromesh mcp` without a workspace path (or `NEUROMESH_WORKSPACE`). Without it the server may bind to your home directory and index unrelated projects. Prefer `neuromesh connect`, which pins an absolute binary path and workspace in MCP config.
 
 Remote / multi-agent: `neuromesh monitor` (optionally `--port 9000` / `neuromesh port 9000`), then SSE and HTTP as in [api.md](api.md).
 
@@ -91,7 +93,9 @@ Cursor-ready template: [agent-rule.mdc](agent-rule.mdc). Same body without YAML 
 | `neuromesh_analyze_impact` | `query`, `depth` | Blast radius |
 | `neuromesh_get_architecture` | — | Languages, packages, entry points |
 | `neuromesh_get_project_memory` | — | Seeded facts |
-| `neuromesh_record_feedback` | `task_success`, `touched_nodes` | STDP on that path |
+| `neuromesh_record_feedback` | `task_success`, `touched_nodes` | STDP on that path; persists `base_relevance` to `graph.bin` |
+| `neuromesh_get_node_weights` | `query` / `symbol` / `path` | Read `access_count`, `base_relevance`, `learning_bonus` (verify learning) |
+| `neuromesh_expand_gap` | `path`, optional `token_cap` | Cheap skeleton for `packet_gaps` paths |
 | `neuromesh_get_stats` | — | Node/edge counts |
 
 Aliases exist for older clients (`activate_context`, `expand_context`, `search_context`, `explain_packet`, `get_context_details`). Prefer the `neuromesh_*` names.
@@ -101,7 +105,7 @@ Aliases exist for older clients (`activate_context`, `expand_context`, `search_c
 `neuromesh_get_context` is the product. Default (`response_detail=minimal`) shape:
 
 - `packet_id` — session key for `neuromesh_explain_packet` (LRU, ~10 minutes, 32 packets)
-- `coverage` — `no_recorded_gap`, `partial`, or `no_seed_resolved` (a string, not an object). `no_recorded_gap` means every *attempted* seed resolved, including each topical cluster of a compound task — not “the packet looks full”
+- `coverage` — `claim` (`no_recorded_gap`, `partial`, `no_seed_resolved`), plus `covered`, `skipped`, `unsure`, `packet_gaps`, and optional `semantic_coverage` for style tasks. `no_recorded_gap` only when every attempted seed resolved **and** `packet_gaps` is empty
 - `tokens.selected` / `tokens.packet` — raw selected vs skeletonized packet
 - `files[]` — `path`, short `why`, skeleton `code`, `folds[]` as descriptors (`fold_id`, `symbol`, `signature`, lines, `saved_tokens`) with **no** `original_body`
 - `missing` / `next` — only when coverage is incomplete; one search action, not a repeated seed list
@@ -119,3 +123,7 @@ Markers look like:
 ```
 
 Pass that `fold_id` to `neuromesh_expand_fold` as `fold_id`, `node_id`, or `query`. The full marker line also works. Folds persist for the **MCP session** (same process, same project). They are not cleared on every `get_context`. A new project id wipes the registry. Ids include a short path tag so two files that both fold `write` do not collide. Fold **bodies** are never in `get_context` or `get_file_skeleton`; only `expand_fold` restores them.
+
+## Learning
+
+`neuromesh_record_feedback` updates `base_relevance`, edge pheromones, and episodic memory on disk (`graph.bin`, `neuromesh.json`). Effects apply on the **next** `get_context` in the same MCP process (search ranking, selector fill, episodic recall). Use `neuromesh_get_node_weights` before and after feedback to verify deltas. Learning does not change a packet mid-request; restart the MCP server to load persisted graph state from a prior session.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -4,7 +4,7 @@ Claims in this project are supposed to come from commands you can run, not from 
 
 ## Gold
 
-`tests/gold_tasks.toml` lists prompts and **path-qualified** gold files. Fixture repos live in `tests/fixtures/` (router, TS store including `require()` CJS + `tokens.json` CSS import, Vue/JS auth+permission-guard compound task with a `directive/permission` ranking thief and forbidden clipboard/profile decoys, session, queue, string config, Python SMS, Kotlin SMS including a natural “received SMS stored” prompt, Dart SMS + Flutter widget, C# SMS, Next SMS route, Pinoox Pinx `get()->action()` plus `MainController::index` → Twig, Vue/PrimeVue `Dashboard.vue` + React `StatCard`, multi-app `apps/com_shop` vs `com_blog`, Laravel Eloquent + `Schema::create` migration + seeder/factory + SQL + JSON config plus route-only `POST /sms` prompts, FastAPI, Rails, Astro, Express route-only `POST /sms`, Nest, Angular, Gin, Axum, ASP.NET MapPost + Razor `@page`, SwiftUI, Remix/React Router, Ktor, LESS/SCSS/CSS badge tokens + SVG `smsInbox` icon, Zod-like schema core vs `packages/bench` + `locales/` + `v3/` + json-schema decoys, plus a `z.infer` → `core.ts` type-alias task), including edit/refactor-style prompts — not only “where is this symbol”.
+`tests/gold_tasks.toml` lists prompts and **path-qualified** gold files. Fixture repos live in `tests/fixtures/` (router, TS store including `require()` CJS + `tokens.json` CSS import, Vue/JS auth+permission-guard compound task with a `directive/permission` ranking thief and forbidden clipboard/profile decoys, **mini-shop** Vue 3 + Pinia + SCSS price-card / dead-code / checkout stepper, session, queue, string config, Python SMS, Kotlin SMS including a natural “received SMS stored” prompt, Dart SMS + Flutter widget, C# SMS, Next SMS route, Pinoox Pinx `get()->action()` plus `MainController::index` → Twig, Vue/PrimeVue `Dashboard.vue` + React `StatCard`, multi-app `apps/com_shop` vs `com_blog`, Laravel Eloquent + `Schema::create` migration + seeder/factory + SQL + JSON config plus route-only `POST /sms` prompts, FastAPI, Rails, Astro, Express route-only `POST /sms`, Nest, Angular, Gin, Axum, ASP.NET MapPost + Razor `@page`, SwiftUI, Remix/React Router, Ktor, LESS/SCSS/CSS badge tokens + SVG `smsInbox` icon, Zod-like schema core vs `packages/bench` + `locales/` + `v3/` + json-schema decoys, plus a `z.infer` → `core.ts` type-alias task), including edit/refactor-style prompts — not only “where is this symbol”.
 
 Thresholds locked in tests:
 
@@ -30,25 +30,36 @@ neuromesh eval
 
 ## Grep after get_context
 
-From `neuromesh eval` on this workspace (release, 2026-08-27, balanced):
+From `neuromesh eval` on this workspace (release, 2026-08-28, balanced):
 
 | Task | WS tok | Selected | Packet | vs WS | vs selected | Recall | Prec | Grep | ms |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| `handle_tool_call_intent` | 531386 | 57835 | 13087 | 97.5% | 77.4% | 1.00 | 0.75 | **0** | 98 |
-| `physarum_usage` | 531386 | 17997 | 3955 | 99.3% | 78.0% | 1.00 | 0.50 | **0** | 57 |
+| `handle_tool_call_intent` | 554554 | 63462 | 15900 | 97.1% | 74.9% | 1.00 | 0.75 | **0** | 33 |
+| `physarum_usage` | 554554 | 18631 | 3945 | 99.3% | 78.8% | 1.00 | 0.50 | **0** | 17 |
 
 That is “did the packet already hold the files a developer would open”, not a live multi-agent trial. Quote this table; do not invent a global 99% figure.
 
+## Shop fixture (mini-shop)
+
+From the same `neuromesh eval` run (balanced, Vue 3 + Pinia + SCSS):
+
+| Task | Recall | Prec | Packet files (gold hit) |
+| :--- | ---: | ---: | :--- |
+| `price_card_scss` | 1.00 | 1.00 | tokens, mixins, ProductCard, `_priceCard.scss` |
+| `dead_code_gocart` | 1.00 | 1.00 | ui.js, App.vue, CartDrawer, Header |
+| `checkout_qty_stepper` | 1.00 | 0.40 | CheckoutView, cart.js (+ connector views) |
+
 ## Index snapshot
 
-From `neuromesh eval` (release, 2026-08-27) on this repository:
+From `neuromesh eval` (release, 2026-08-28) on this repository:
 
 | Metric | Value |
 | :--- | ---: |
-| Files | 304 (`target/` ignored) |
-| Nodes | 2,123 |
-| Edges | 5,056 |
-| Index time (release) | ~1,573 ms |
+| Files | 323 (`target/` ignored) |
+| Nodes | 2,458 |
+| Edges | 5,594 |
+| Workspace tokens | 554,554 |
+| Index time (release) | ~490 ms |
 
 Index file cap is **auto** by default (production sources first, tests last, ceiling 50,000). Override with `neuromesh index --max-files N`. See [cli.md](cli.md#index-file-cap).
 
@@ -60,12 +71,12 @@ From `snapshot_load_and_single_file_reindex_beat_full_index` (release, this repo
 
 | Metric | Value |
 | :--- | ---: |
-| Files scanned | 305 |
-| Nodes | 2,245 |
-| Full workspace index | 1,296 ms |
-| Snapshot size | 3.0 MB |
-| **Snapshot cold load** | **63 ms** |
-| **One-file reindex** (parse + local relink) | **140 ms** |
+| Files scanned | 323 |
+| Nodes | 2,458 |
+| Full workspace index | 1,314 ms |
+| Snapshot size | 3.3 MB |
+| **Snapshot cold load** | **57 ms** |
+| **One-file reindex** (parse + local relink) | **111 ms** |
 
 ```bash
 cargo test --release -p neuromesh-graph --lib snapshot_load_and_single_file_reindex -- --nocapture

--- a/editors/vscode-neuromesh/README.md
+++ b/editors/vscode-neuromesh/README.md
@@ -2,7 +2,7 @@
 
 Sidebar mesh stats, a packet inspector, fold CodeLens, and the galaxy UI — talking to a running `neuromesh monitor`.
 
-The agent loop in the editor matches 0.7.6: **get_context → expand_fold**. Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**.
+The agent loop in the editor matches 0.7.7: **get_context → expand_fold** (or **expand_gap** for `packet_gaps`). Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**; use **get_node_weights** to verify learning deltas.
 
 ## Install
 

--- a/editors/vscode-neuromesh/package.json
+++ b/editors/vscode-neuromesh/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-neuromesh",
   "displayName": "NeuroMesh",
   "description": "Evidence packets, reversible folds, and a live mesh sidebar for Cursor & VS Code. Don’t dump files — fold them.",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "publisher": "neuromesh",
   "license": "MIT",
   "homepage": "https://github.com/pinoox/neuromesh",

--- a/tests/fixtures/mini-shop/gold_tasks.toml
+++ b/tests/fixtures/mini-shop/gold_tasks.toml
@@ -1,0 +1,38 @@
+[[task]]
+id = "price_card_scss"
+prompt = "Create a new price-card SCSS partial reusing design tokens and mixins, following ProductCard styling patterns with hover-lift"
+gold_files = [
+  "src/styles/tokens.scss",
+  "src/styles/mixins.scss",
+  "src/components/ProductCard.vue",
+  "src/styles/_priceCard.scss",
+]
+forbidden_files = [
+  "src/components/PromoCodeInput.vue",
+  "src/components/CartDrawer.vue",
+  "src/views/CartView.vue",
+  "src/views/CheckoutView.vue",
+]
+expect_seeds_missed = false
+
+[[task]]
+id = "dead_code_gocart"
+prompt = "Find unused goCart in the ui store and list all references to goCart across the project"
+gold_files = [
+  "src/stores/ui.js",
+  "src/App.vue",
+  "src/components/CartDrawer.vue",
+  "src/components/Header.vue",
+]
+forbidden_files = []
+expect_seeds_missed = false
+
+[[task]]
+id = "checkout_qty_stepper"
+prompt = "Add quantity stepper in checkout list using setQty from cart store"
+gold_files = [
+  "src/views/CheckoutView.vue",
+  "src/stores/cart.js",
+]
+forbidden_files = []
+expect_seeds_missed = false

--- a/tests/fixtures/mini-shop/src/App.vue
+++ b/tests/fixtures/mini-shop/src/App.vue
@@ -1,0 +1,23 @@
+<script setup>
+import { useUiStore } from './stores/ui'
+import Header from './components/Header.vue'
+import CartDrawer from './components/CartDrawer.vue'
+import CartView from './views/CartView.vue'
+import CheckoutView from './views/CheckoutView.vue'
+
+const ui = useUiStore()
+</script>
+
+<template>
+  <Header />
+
+  <CartView v-if="ui.currentView === 'cart'" />
+  <CheckoutView v-else-if="ui.currentView === 'checkout'" />
+
+  <CartDrawer />
+</template>
+
+<style lang="scss" scoped>
+@use './styles/tokens.scss' as *;
+@use './styles/mixins.scss' as *;
+</style>

--- a/tests/fixtures/mini-shop/src/components/AppButton.vue
+++ b/tests/fixtures/mini-shop/src/components/AppButton.vue
@@ -1,0 +1,52 @@
+<script setup>
+defineProps({
+  variant: {
+    type: String,
+    default: 'primary', // primary | ghost
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+})
+</script>
+
+<template>
+  <button class="app-button" :class="`app-button--${variant}`" :disabled="disabled">
+    <slot />
+  </button>
+</template>
+
+<style lang="scss" scoped>
+@use '../styles/tokens.scss' as *;
+@use '../styles/mixins.scss' as *;
+
+.app-button {
+  border: none;
+  border-radius: $radius-sm;
+  padding: $space-2 $space-4;
+  font-weight: 600;
+  background: $color-brand;
+  color: $color-surface;
+  transition: background 0.15s ease, opacity 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background: $color-brand-dark;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &--ghost {
+    background: transparent;
+    color: $color-brand;
+    border: 1px solid $color-border;
+
+    &:hover:not(:disabled) {
+      background: $color-surface-alt;
+    }
+  }
+}
+</style>

--- a/tests/fixtures/mini-shop/src/components/CartDrawer.vue
+++ b/tests/fixtures/mini-shop/src/components/CartDrawer.vue
@@ -1,0 +1,154 @@
+<script setup>
+import { useCartStore } from '@/stores/cart'
+import { useUiStore } from '@/stores/ui'
+import AppButton from './AppButton.vue'
+import PromoCodeInput from './PromoCodeInput.vue'
+
+const cart = useCartStore()
+const ui = useUiStore()
+</script>
+
+<template>
+  <div v-if="ui.cartOpen" class="cart-overlay" @click.self="ui.closeCart()">
+    <aside class="cart-drawer" data-testid="cart-drawer">
+      <header class="cart-drawer__header">
+        <h2>Your cart ({{ cart.count }})</h2>
+        <button class="cart-drawer__legacy" v-show="false" @click="ui.goCart()">legacy</button>
+        <button class="cart-drawer__close" @click="ui.closeCart()">×</button>
+      </header>
+
+      <div class="cart-drawer__empty" v-if="cart.items.length === 0">
+        Your cart is empty.
+      </div>
+
+      <ul v-else class="cart-drawer__items">
+        <li v-for="item in cart.items" :key="item.id" class="cart-drawer__item">
+          <div class="cart-drawer__meta">
+            <span>{{ item.name }}</span>
+            <small>${{ item.price }} × {{ item.qty }}</small>
+          </div>
+          <button class="cart-drawer__remove" @click="cart.remove(item.id)">Remove</button>
+        </li>
+      </ul>
+
+      <footer class="cart-drawer__footer">
+        <PromoCodeInput />
+        <div class="cart-drawer__line">
+          <span>Subtotal</span>
+          <strong>${{ cart.subtotal }}</strong>
+        </div>
+        <div class="cart-drawer__line" v-if="cart.discount > 0">
+          <span>Discount</span>
+          <strong class="cart-drawer__discount">−${{ cart.discount }}</strong>
+        </div>
+        <div class="cart-drawer__line cart-drawer__line--total">
+          <span>Total</span>
+          <strong>${{ cart.total }}</strong>
+        </div>
+        <AppButton class="cart-drawer__checkout" @click="ui.goCheckout()">
+          Checkout
+        </AppButton>
+      </footer>
+    </aside>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use '../styles/tokens.scss' as *;
+@use '../styles/mixins.scss' as *;
+
+.cart-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(31, 41, 55, 0.45);
+  z-index: 40;
+}
+
+.cart-drawer {
+  @include card-base;
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: min(380px, 100vw);
+  display: flex;
+  flex-direction: column;
+  box-shadow: $shadow-lift;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: $space-4;
+    border-bottom: 1px solid $color-border;
+  }
+
+  &__close {
+    background: none;
+    border: none;
+    font-size: 22px;
+    color: $color-text-muted;
+  }
+
+  &__empty {
+    padding: $space-5;
+    text-align: center;
+    color: $color-text-muted;
+  }
+
+  &__items {
+    list-style: none;
+    margin: 0;
+    padding: $space-3;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: $space-3 0;
+    border-bottom: 1px solid $color-border;
+
+    small {
+      color: $color-text-muted;
+    }
+  }
+
+  &__remove {
+    background: none;
+    border: none;
+    color: $color-danger;
+    font-size: 13px;
+  }
+
+  &__footer {
+    padding: $space-4;
+    border-top: 1px solid $color-border;
+    display: flex;
+    flex-direction: column;
+    gap: $space-3;
+  }
+
+  &__line {
+    display: flex;
+    justify-content: space-between;
+
+    &--total {
+      border-top: 1px solid $color-border;
+      padding-top: $space-3;
+      font-size: 18px;
+    }
+  }
+
+  &__discount {
+    color: $color-success;
+  }
+
+  &__checkout {
+    width: 100%;
+    margin-top: $space-1;
+  }
+}
+</style>

--- a/tests/fixtures/mini-shop/src/components/Header.vue
+++ b/tests/fixtures/mini-shop/src/components/Header.vue
@@ -1,0 +1,85 @@
+<script setup>
+import { useCartStore } from '@/stores/cart'
+import { useUiStore } from '@/stores/ui'
+
+const cart = useCartStore()
+const ui = useUiStore()
+</script>
+
+<template>
+  <header class="header">
+    <div class="container header__inner">
+      <button class="header__logo" @click="ui.goCart(); ui.currentView = 'home'">
+        ☁ Nimbus
+      </button>
+
+      <nav class="header__nav">
+        <button @click="ui.currentView = 'home'">Shop</button>
+        <button class="header__cart" @click="ui.openCart()" aria-label="Open cart">
+          Cart
+          <span v-if="cart.count > 0" class="header__count">{{ cart.count }}</span>
+        </button>
+      </nav>
+    </div>
+  </header>
+</template>
+
+<style lang="scss" scoped>
+@use '../styles/tokens.scss' as *;
+@use '../styles/mixins.scss' as *;
+
+.header {
+  background: $color-surface;
+  border-bottom: 1px solid $color-border;
+  position: sticky;
+  top: 0;
+  z-index: 30;
+
+  &__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-top: $space-3;
+    padding-bottom: $space-3;
+  }
+
+  &__logo {
+    background: none;
+    border: none;
+    font-size: 20px;
+    font-weight: 700;
+    color: $color-brand;
+  }
+
+  &__nav {
+    display: flex;
+    gap: $space-4;
+    align-items: center;
+
+    button {
+      background: none;
+      border: none;
+      color: $color-text;
+    }
+  }
+
+  &__cart {
+    position: relative;
+  }
+
+  &__count {
+    position: absolute;
+    top: -8px;
+    right: -10px;
+    background: $color-accent;
+    color: $color-text;
+    font-size: 11px;
+    font-weight: 700;
+    width: 18px;
+    height: 18px;
+    border-radius: $radius-pill;
+    display: grid;
+    place-items: center;
+  }
+}
+</style>

--- a/tests/fixtures/mini-shop/src/components/ProductCard.vue
+++ b/tests/fixtures/mini-shop/src/components/ProductCard.vue
@@ -1,0 +1,116 @@
+<script setup>
+import AppButton from './AppButton.vue'
+
+defineProps({
+  product: {
+    type: Object,
+    required: true,
+  },
+})
+
+defineEmits(['view', 'add'])
+</script>
+
+<template>
+  <article class="product-card" data-testid="product-card">
+    <div class="product-card__media">
+      <span class="product-card__badge" v-if="!product.inStock">Out of stock</span>
+    </div>
+
+    <div class="product-card__body">
+      <span class="product-card__category">{{ product.category }}</span>
+      <h3 class="product-card__title">{{ product.name }}</h3>
+      <p class="product-card__description">{{ product.description }}</p>
+    </div>
+
+    <div class="product-card__footer">
+      <strong class="product-card__price">${{ product.price }}</strong>
+      <div class="product-card__actions">
+        <AppButton variant="ghost" @click="$emit('view', product.id)">Details</AppButton>
+        <AppButton :disabled="!product.inStock" @click="$emit('add', product)">
+          Add
+        </AppButton>
+      </div>
+    </div>
+  </article>
+</template>
+
+<style lang="scss" scoped>
+@use '../styles/tokens.scss' as *;
+@use '../styles/mixins.scss' as *;
+
+.product-card {
+  @include card-base;
+  @include hover-lift;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: $space-3;
+
+  &:focus-within {
+    outline: 2px solid $color-brand;
+    outline-offset: 2px;
+  }
+
+  &__media {
+    height: 140px;
+    background:
+      linear-gradient(135deg, lighten($color-brand, 28%), lighten($color-accent, 32%));
+    position: relative;
+    border-radius: $radius-lg $radius-lg 0 0;
+  }
+
+  &__badge {
+    position: absolute;
+    top: $space-2;
+    left: $space-2;
+    background: $color-danger;
+    color: $color-surface;
+    font-size: 12px;
+    padding: $space-1 $space-2;
+    border-radius: $radius-pill;
+  }
+
+  &__body {
+    padding: 0 $space-3;
+  }
+
+  &__category {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: $color-brand;
+    font-weight: 600;
+  }
+
+  &__title {
+    font-size: 18px;
+    margin: $space-1 0;
+  }
+
+  &__description {
+    color: $color-text-muted;
+    font-size: 14px;
+    margin: 0;
+  }
+
+  &__footer {
+    margin-top: auto;
+    padding: $space-3;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-top: 1px solid $color-border;
+  }
+
+  &__price {
+    font-size: 18px;
+    color: $color-brand-dark;
+  }
+
+  &__actions {
+    display: flex;
+    gap: $space-2;
+  }
+}
+</style>

--- a/tests/fixtures/mini-shop/src/components/PromoCodeInput.vue
+++ b/tests/fixtures/mini-shop/src/components/PromoCodeInput.vue
@@ -1,0 +1,57 @@
+<script setup>
+import { ref } from 'vue'
+import { useCartStore } from '@/stores/cart'
+
+const cart = useCartStore()
+const input = ref('')
+
+function submit() {
+  if (!input.value.trim()) return
+  cart.applyPromo(input.value)
+  input.value = ''
+}
+</script>
+
+<template>
+  <form class="promo-code" @submit.prevent="submit">
+    <input
+      v-model="input"
+      class="promo-code__input"
+      placeholder="Promo code (try WELCOME10)"
+      aria-label="Promo code"
+    />
+    <button class="promo-code__apply" type="submit">Apply</button>
+  </form>
+</template>
+
+<style lang="scss" scoped>
+@use '../styles/tokens.scss' as *;
+@use '../styles/mixins.scss' as *;
+
+.promo-code {
+  display: flex;
+  gap: $space-2;
+
+  &__input {
+    flex: 1;
+    padding: $space-2;
+    border: 1px solid $color-border;
+    border-radius: $radius-sm;
+    font: inherit;
+
+    &:focus {
+      outline: 2px solid $color-brand;
+      outline-offset: -1px;
+    }
+  }
+
+  &__apply {
+    border: none;
+    border-radius: $radius-sm;
+    background: $color-accent;
+    color: $color-text;
+    font-weight: 700;
+    padding: 0 $space-4;
+  }
+}
+</style>

--- a/tests/fixtures/mini-shop/src/data/products.js
+++ b/tests/fixtures/mini-shop/src/data/products.js
@@ -1,0 +1,34 @@
+export const products = [
+  {
+    id: 1,
+    name: 'Aurora Desk Lamp',
+    price: 49,
+    category: 'lighting',
+    description: 'Warm dimmable LED with a sculpted aluminum arm.',
+    inStock: true,
+  },
+  {
+    id: 2,
+    name: 'Halo Speaker',
+    price: 129,
+    category: 'audio',
+    description: '360° sound in a matte ceramic housing.',
+    inStock: true,
+  },
+  {
+    id: 3,
+    name: 'Mesa Cutting Board',
+    price: 39,
+    category: 'kitchen',
+    description: 'Solid oak board that doubles as a serving tray.',
+    inStock: false,
+  },
+  {
+    id: 4,
+    name: 'Drift Backpack',
+    price: 89,
+    category: 'travel',
+    description: 'Water-resistant 20L pack with a padded laptop sleeve.',
+    inStock: true,
+  },
+]

--- a/tests/fixtures/mini-shop/src/main.js
+++ b/tests/fixtures/mini-shop/src/main.js
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import App from './App.vue'
+import './styles/global.scss'
+
+createApp(App).use(createPinia()).mount('#app')

--- a/tests/fixtures/mini-shop/src/stores/cart.js
+++ b/tests/fixtures/mini-shop/src/stores/cart.js
@@ -1,0 +1,61 @@
+import { defineStore } from 'pinia'
+import { products } from '../data/products'
+
+const PROMO_CODES = {
+  WELCOME10: 0.1,
+  NIMBUS20: 0.2,
+}
+
+export const useCartStore = defineStore('cart', {
+  state: () => ({
+    items: [],
+    promoCode: '',
+  }),
+
+  getters: {
+    count(state) {
+      return state.items.reduce((sum, item) => sum + item.qty, 0)
+    },
+
+    subtotal(state) {
+      return state.items.reduce((sum, item) => sum + item.price * item.qty, 0)
+    },
+
+    discount(state) {
+      return Math.round(state.subtotal * (PROMO_CODES[state.promoCode] ?? 0))
+    },
+
+    total() {
+      return this.subtotal - this.discount
+    },
+  },
+
+  actions: {
+    add(product) {
+      const existing = this.items.find((item) => item.id === product.id)
+      if (existing) {
+        existing.qty += 1
+      } else {
+        this.items.push({ id: product.id, name: product.name, price: product.price, qty: 1 })
+      }
+    },
+
+    remove(productId) {
+      this.items = this.items.filter((item) => item.id !== productId)
+    },
+
+    setQty(productId, qty) {
+      const item = this.items.find((i) => i.id === productId)
+      if (item) item.qty = Math.max(1, qty)
+    },
+
+    applyPromo(code) {
+      this.promoCode = code.trim().toUpperCase()
+    },
+
+    clear() {
+      this.items = []
+      this.promoCode = ''
+    },
+  },
+})

--- a/tests/fixtures/mini-shop/src/stores/ui.js
+++ b/tests/fixtures/mini-shop/src/stores/ui.js
@@ -1,0 +1,41 @@
+import { defineStore } from 'pinia'
+
+export const useUiStore = defineStore('ui', {
+  state: () => ({
+    currentView: 'home', // home | product | cart
+    selectedProductId: null,
+    cartOpen: false,
+    toast: null,
+  }),
+
+  actions: {
+    openProduct(id) {
+      this.selectedProductId = id
+      this.currentView = 'product'
+    },
+
+    openCart() {
+      this.cartOpen = true
+    },
+
+    closeCart() {
+      this.cartOpen = false
+    },
+
+    goCheckout() {
+      this.cartOpen = false
+      this.currentView = 'checkout'
+    },
+
+    goCart() {
+      this.currentView = 'cart'
+    },
+
+    showToast(message) {
+      this.toast = { message, id: Date.now() }
+      setTimeout(() => {
+        this.toast = null
+      }, 2500)
+    },
+  },
+})

--- a/tests/fixtures/mini-shop/src/styles/_priceCard.scss
+++ b/tests/fixtures/mini-shop/src/styles/_priceCard.scss
@@ -1,0 +1,13 @@
+@use './tokens' as *;
+
+@mixin price-card-tile {
+  background: linear-gradient(135deg, $color-brand, $color-brand-dark);
+  color: $color-surface;
+  border-radius: $radius-lg;
+  box-shadow: $shadow-card;
+
+  &:focus-visible {
+    outline: 2px solid $color-accent;
+    outline-offset: 2px;
+  }
+}

--- a/tests/fixtures/mini-shop/src/styles/global.scss
+++ b/tests/fixtures/mini-shop/src/styles/global.scss
@@ -1,0 +1,40 @@
+@use './tokens' as *;
+@use './mixins' as *;
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: $font-body;
+  color: $color-text;
+  background: $color-surface-alt;
+  line-height: 1.5;
+}
+
+h1, h2, h3, h4 {
+  margin-top: 0;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.container {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: $space-4;
+
+  @include responsive(md) {
+    padding: $space-5;
+  }
+}

--- a/tests/fixtures/mini-shop/src/styles/mixins.scss
+++ b/tests/fixtures/mini-shop/src/styles/mixins.scss
@@ -1,0 +1,33 @@
+@use './tokens' as *;
+
+@mixin card-base {
+  background: $color-surface;
+  border: 1px solid $color-border;
+  border-radius: $radius-md;
+  box-shadow: $shadow-card;
+}
+
+@mixin hover-lift {
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: $shadow-lift;
+  }
+}
+
+@mixin responsive($name) {
+  @if $name == sm {
+    @media (min-width: $break-sm) {
+      @content;
+    }
+  } @else if $name == md {
+    @media (min-width: $break-md) {
+      @content;
+    }
+  } @else if $name == lg {
+    @media (min-width: $break-lg) {
+      @content;
+    }
+  }
+}

--- a/tests/fixtures/mini-shop/src/styles/tokens.scss
+++ b/tests/fixtures/mini-shop/src/styles/tokens.scss
@@ -1,0 +1,31 @@
+$color-brand: #7c3aed;
+$color-brand-dark: #5b21b6;
+$color-accent: #f59e0b;
+$color-success: #059669;
+$color-danger: #dc2626;
+$color-text: #1f2937;
+$color-text-muted: #6b7280;
+$color-surface: #ffffff;
+$color-surface-alt: #f9fafb;
+$color-border: #e5e7eb;
+
+$radius-sm: 6px;
+$radius-md: 10px;
+$radius-lg: 16px;
+$radius-pill: 999px;
+
+$shadow-card: 0 1px 3px rgba(0, 0, 0, 0.08), 0 4px 12px rgba(0, 0, 0, 0.06);
+$shadow-lift: 0 8px 24px rgba(0, 0, 0, 0.12);
+
+$space-1: 4px;
+$space-2: 8px;
+$space-3: 12px;
+$space-4: 16px;
+$space-5: 24px;
+$space-6: 32px;
+
+$break-sm: 640px;
+$break-md: 768px;
+$break-lg: 1024px;
+
+$font-body: 'Inter', system-ui, -apple-system, sans-serif;

--- a/tests/fixtures/mini-shop/src/views/CartView.vue
+++ b/tests/fixtures/mini-shop/src/views/CartView.vue
@@ -1,0 +1,109 @@
+<script setup>
+import { useCartStore } from '@/stores/cart'
+import { useUiStore } from '@/stores/ui'
+import AppButton from '@/components/AppButton.vue'
+import PromoCodeInput from '@/components/PromoCodeInput.vue'
+
+const cart = useCartStore()
+const ui = useUiStore()
+
+function placeOrder() {
+  cart.clear()
+  ui.showToast('Order placed — thank you!')
+  ui.currentView = 'home'
+}
+</script>
+
+<template>
+  <main class="container" data-testid="cart-view">
+    <h1>Your cart</h1>
+
+    <p v-if="cart.items.length === 0" class="cart-view__empty">Nothing here yet.</p>
+
+    <template v-else>
+      <ul class="cart-view__list">
+        <li v-for="item in cart.items" :key="item.id" class="cart-view__item">
+          <div>
+            <strong>{{ item.name }}</strong>
+            <p>${{ item.price }} each</p>
+          </div>
+          <button class="cart-view__remove" @click="cart.remove(item.id)">Remove</button>
+        </li>
+      </ul>
+
+      <aside class="cart-view__summary">
+        <PromoCodeInput />
+        <p class="cart-view__line">Subtotal <span>${{ cart.subtotal }}</span></p>
+        <p v-if="cart.discount" class="cart-view__line cart-view__line--discount">
+          Discount <span>−${{ cart.discount }}</span>
+        </p>
+        <p class="cart-view__line cart-view__line--total">
+          Total <span>${{ cart.total }}</span>
+        </p>
+        <AppButton class="cart-view__order" @click="placeOrder">Place order</AppButton>
+      </aside>
+    </template>
+  </main>
+</template>
+
+<style lang="scss" scoped>
+@use '../styles/tokens.scss' as *;
+@use '../styles/mixins.scss' as *;
+
+.cart-view {
+  &__list {
+    list-style: none;
+    margin: $space-4 0;
+    padding: 0;
+    display: grid;
+    gap: $space-3;
+  }
+
+  &__item {
+    @include card-base;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: $space-4;
+
+    p {
+      margin: $space-1 0 0;
+      color: $color-text-muted;
+    }
+  }
+
+  &__remove {
+    border: none;
+    background: none;
+    color: $color-danger;
+  }
+
+  &__summary {
+    @include card-base;
+    padding: $space-4;
+    max-width: 360px;
+  }
+
+  &__line {
+    display: flex;
+    justify-content: space-between;
+    margin: $space-2 0;
+
+    &--discount span {
+      color: $color-success;
+    }
+
+    &--total {
+      font-size: 18px;
+      font-weight: 700;
+      border-top: 1px solid $color-border;
+      padding-top: $space-3;
+    }
+  }
+
+  &__order {
+    width: 100%;
+    margin-top: $space-3;
+  }
+}
+</style>

--- a/tests/fixtures/mini-shop/src/views/CheckoutView.vue
+++ b/tests/fixtures/mini-shop/src/views/CheckoutView.vue
@@ -1,0 +1,156 @@
+<script setup>
+import { useCartStore } from '@/stores/cart'
+import { useUiStore } from '@/stores/ui'
+import AppButton from '@/components/AppButton.vue'
+import PromoCodeInput from '@/components/PromoCodeInput.vue'
+
+const cart = useCartStore()
+const ui = useUiStore()
+
+function placeOrder() {
+  cart.clear()
+  ui.showToast('Order placed — thank you!')
+  ui.currentView = 'home'
+}
+</script>
+
+<template>
+  <main class="container" data-testid="checkout-view">
+    <h1>Checkout</h1>
+
+    <p v-if="cart.items.length === 0" class="checkout__empty">Nothing to check out.</p>
+
+    <template v-else>
+      <section class="checkout__summary">
+        <h2>Order summary</h2>
+        <ul class="checkout__list">
+          <li v-for="item in cart.items" :key="item.id" class="checkout__item">
+            <div class="checkout__item-info">
+              <span>{{ item.name }}</span>
+              <div class="checkout__stepper">
+                <button
+                  type="button"
+                  class="checkout__step"
+                  @click="cart.setQty(item.id, item.qty - 1)"
+                >−</button>
+                <span class="checkout__step-value">{{ item.qty }}</span>
+                <button
+                  type="button"
+                  class="checkout__step"
+                  @click="cart.setQty(item.id, item.qty + 1)"
+                >+</button>
+              </div>
+            </div>
+            <strong>${{ item.price * item.qty }}</strong>
+          </li>
+        </ul>
+
+        <PromoCodeInput />
+
+        <p class="checkout__line">Subtotal <span>${{ cart.subtotal }}</span></p>
+        <p v-if="cart.discount" class="checkout__line checkout__line--discount">
+          Discount <span>−${{ cart.discount }}</span>
+        </p>
+        <p class="checkout__line checkout__line--total">
+          Total <span>${{ cart.total }}</span>
+        </p>
+
+        <AppButton class="checkout__place" @click="placeOrder">Place order</AppButton>
+        <AppButton variant="ghost" class="checkout__back" @click="ui.currentView = 'cart'">
+          Back to cart
+        </AppButton>
+      </section>
+    </template>
+  </main>
+</template>
+
+<style lang="scss" scoped>
+@use '../styles/tokens.scss' as *;
+@use '../styles/mixins.scss' as *;
+
+.checkout {
+  &__empty {
+    color: $color-text-muted;
+  }
+
+  &__summary {
+    @include card-base;
+    max-width: 440px;
+    padding: $space-5;
+  }
+
+  &__list {
+    list-style: none;
+    margin: $space-3 0;
+    padding: 0;
+    display: grid;
+    gap: $space-2;
+    border-top: 1px solid $color-border;
+  }
+
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: $space-3;
+  }
+
+  &__item-info {
+    display: flex;
+    flex-direction: column;
+    gap: $space-2;
+  }
+
+  &__stepper {
+    display: inline-flex;
+    align-items: center;
+    gap: $space-2;
+  }
+
+  &__step {
+    width: 24px;
+    height: 24px;
+    border: 1px solid $color-border;
+    border-radius: $radius-sm;
+    background: $color-surface-alt;
+    line-height: 1;
+
+    &:hover {
+      background: lighten($color-brand, 40%);
+    }
+  }
+
+  &__step-value {
+    min-width: 16px;
+    text-align: center;
+    font-weight: 600;
+  }
+
+  &__line {
+    display: flex;
+    justify-content: space-between;
+    margin: $space-2 0;
+
+    &--discount span {
+      color: $color-success;
+    }
+
+    &--total {
+      font-size: 18px;
+      font-weight: 700;
+      border-top: 1px solid $color-border;
+      padding-top: $space-3;
+    }
+  }
+
+  &__place {
+    width: 100%;
+    margin-top: $space-4;
+  }
+
+  &__back {
+    width: 100%;
+    margin-top: $space-2;
+  }
+}
+</style>


### PR DESCRIPTION
Benchmark-driven routing, honest coverage, and a falsifiable learning loop (Vue shop fixture).

- **Shop gold fixture.** `tests/fixtures/mini-shop/` (Vue 3 + Pinia + SCSS) with gold tasks for price-card SCSS (T6), dead-code `goCart` (T7), and checkout `setQty` (T5). Runs in `gold_harness_on_fixture_repos`.
- **Style routing.** Unified SCSS file hints (`tokens.scss` / `mixins.scss` with and without `_`), `_priceCard.scss` seeds, StyleToken search seeds, and cart/promo noise filtering so style tasks do not ship cart components.
- **View seeds.** `related_concepts` become seeds; checkout/stepper prompts inject `CheckoutView` without `checkout` ⊃ `cart` false positives; focused checkout tasks tighten optional fill.
- **Coverage honesty.** `CoverageReport` adds `covered`, `skipped`, `semantic_coverage`, and `packet_gaps` (with optional `line`). `no_recorded_gap` only when seeds and packet gaps are both empty.
- **Structural proof.** `structural_evidence` includes `exact_line`, `who_reads`, `callers_count`, and `is_dead`; bug-hunt tasks can emit `bug_line` gaps (e.g. duplicate discount in `total()`).
- **Vue template → store.** `@click` / `@submit` handlers (`ui.goCart()`) emit `Calls` edges to Pinia actions for dead-code and caller tracing.
- **Learning loop.** `record_feedback` resolves human names, persists `base_relevance` to `graph.bin`, saves episodes, reinforces callee edges, and recalls successful episodes on the next `get_context`. `neuromesh_get_node_weights` exposes deltas for verification.
- **New MCP tools.** `neuromesh_expand_gap` (cheap skeleton for gap paths) and `neuromesh_get_node_weights` (observability).
- **Selector / skeleton.** `learning_bonus` boosts file fill from `access_count` / `base_relevance`; files ≤60 lines fold more aggressively.
- **Docs / ops.** README and [mcp.md](mcp.md) warn against `mcp` without a workspace path; [mcp.md](mcp.md) documents learning timing and new tools.