### PR TITLE
Persist learning across sessions and improve Vue trace visuals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-api"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "futures-util",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cache"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cli"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "dirs",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-context"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-core"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "dirs",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-graph"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "bincode",
  "chrono",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-index"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "blake3",
  "chrono",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-local-ai"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "neuromesh-core",
  "parking_lot",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-mcp"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "neuromesh-cache",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-memory"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "dirs",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-observability"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "dirs",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-parser"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "neuromesh-core",
  "neuromesh-index",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-provider"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "futures-util",
  "neuromesh-core",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-router"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "neuromesh-context",
  "neuromesh-core",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-task"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "neuromesh-core",
  "neuromesh-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 exclude = ["tests/fixtures/mini-axum"]
 
 [workspace.package]
-version = "0.7.7"
+version = "0.7.8"
 edition = "2021"
 rust-version = "1.80"
 authors = ["NeuroMesh Team <team@neuromesh.local>"]

--- a/README.md
+++ b/README.md
@@ -318,6 +318,6 @@ Index snapshot from that eval run: **323 files · 2,458 nodes · 5,594 edges · 
 | [MCP](docs/mcp.md) · [CLI](docs/cli.md) | Tools and commands |
 | [Quality](docs/quality.md) | Gold, eval, numbers |
 | [Contributing](docs/contributing.md) | Come build a solver or a language |
-| [Changelog](docs/CHANGELOG.md) | 0.7.7 |
+| [Changelog](docs/CHANGELOG.md) | 0.7.8 |
 
 MIT · [LICENSE](LICENSE)

--- a/crates/neuromesh-cli/src/main.rs
+++ b/crates/neuromesh-cli/src/main.rs
@@ -151,6 +151,14 @@ async fn async_main(command: &str, args: &[String]) -> Result<()> {
                 neuromesh_memory::WorkingMemory::default(),
             ));
 
+            let cap = commands::max_files_from_args(args)?;
+            let _ = graph.load_persisted(&current_dir);
+            let _ = neuromesh_mcp::warmup_project_learning(
+                memory_db.as_ref(),
+                graph.as_ref(),
+                &project_id,
+            );
+
             let handler = Arc::new(neuromesh_mcp::McpToolHandler::new(
                 graph.clone(),
                 activator,
@@ -158,9 +166,6 @@ async fn async_main(command: &str, args: &[String]) -> Result<()> {
                 memory_db,
                 working_memory,
             ));
-
-            let cap = commands::max_files_from_args(args)?;
-            let _ = graph.load_persisted(&current_dir);
             if graph.stats().total_nodes == 0
                 && neuromesh_index::ProjectWalker::is_safe_workspace(&current_dir)
             {

--- a/crates/neuromesh-graph/src/graph.rs
+++ b/crates/neuromesh-graph/src/graph.rs
@@ -937,6 +937,34 @@ impl NeuralProjectGraph {
         if matches.len() == 1 {
             return matches.into_iter().next();
         }
+        if path_like && matches.is_empty() {
+            if let Some(stem) = Path::new(&hint_norm)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+            {
+                for (path, ids) in &data.file_to_nodes {
+                    let path_s = normalize_path_hint(&path.to_string_lossy());
+                    if path_s.ends_with(&format!("/{stem}"))
+                        || path_s.ends_with(&stem)
+                        || path_s.contains(&format!("/{stem}."))
+                    {
+                        for id in ids {
+                            if data
+                                .mesh
+                                .node(id)
+                                .is_some_and(|n| n.node_type == NodeType::File)
+                            {
+                                matches.push(id.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if matches.len() == 1 {
+            return matches.into_iter().next();
+        }
         if path_like && matches.len() > 1 {
             let suffix: Vec<NodeId> = matches
                 .into_iter()
@@ -1164,21 +1192,30 @@ impl NeuralProjectGraph {
                 .strip_prefix("impl:")
                 .or_else(|| hint.strip_prefix("type:"))
                 .unwrap_or(hint);
-            let key = format!("{}::{}", type_name.to_lowercase(), name.to_lowercase());
+            let keys = [
+                format!("{}::{}", type_name.to_lowercase(), name.to_lowercase()),
+                format!(
+                    "{}::{}",
+                    pinia_store_type_from_alias(type_name).to_lowercase(),
+                    name.to_lowercase()
+                ),
+            ];
             let data = self.inner.read();
-            if let Some(ids) = data.impl_index.get(&key) {
-                if ids.len() == 1 {
-                    return Some((ids[0].clone(), EdgeConfidence::Proven));
-                }
-                if let Some(id) = ids.iter().find(|id| {
-                    data.mesh
-                        .node(id)
-                        .is_some_and(|n| n.file_path == source_file)
-                }) {
-                    return Some((id.clone(), EdgeConfidence::Proven));
-                }
-                if !ids.is_empty() {
-                    return Some((ids[0].clone(), EdgeConfidence::Likely));
+            for key in &keys {
+                if let Some(ids) = data.impl_index.get(key) {
+                    if ids.len() == 1 {
+                        return Some((ids[0].clone(), EdgeConfidence::Proven));
+                    }
+                    if let Some(id) = ids.iter().find(|id| {
+                        data.mesh
+                            .node(id)
+                            .is_some_and(|n| n.file_path == source_file)
+                    }) {
+                        return Some((id.clone(), EdgeConfidence::Proven));
+                    }
+                    if !ids.is_empty() {
+                        return Some((ids[0].clone(), EdgeConfidence::Likely));
+                    }
                 }
             }
         }
@@ -1730,17 +1767,17 @@ impl NeuralProjectGraph {
         direction: TraceDirection,
         depth: usize,
     ) -> TraceResult {
-        let origin_node = self.resolve_best(query);
-        let Some(origin) = origin_node else {
+        let Some((origin, match_reason, origin_reliable)) = self.resolve_trace_origin(query) else {
             return TraceResult {
                 origin: None,
+                origin_reliable: true,
                 hops: Vec::new(),
                 callers: Vec::new(),
                 callees: Vec::new(),
             };
         };
         let depth = depth.clamp(1, 6);
-        let origin_hit = SearchHit::from_node(&origin, 1.0, "origin");
+        let origin_hit = SearchHit::from_node(&origin, 1.0, match_reason);
         let mut hops = Vec::new();
         let mut callers = Vec::new();
         let mut callees = Vec::new();
@@ -1801,9 +1838,71 @@ impl NeuralProjectGraph {
 
         TraceResult {
             origin: Some(origin_hit),
+            origin_reliable,
             hops,
             callers,
             callees,
+        }
+    }
+
+    /// Resolve a trace seed with explicit match quality (exact vs fuzzy).
+    pub fn resolve_trace_origin(&self, query: &str) -> Option<(ContextNode, String, bool)> {
+        let query = query.trim();
+        if query.is_empty() {
+            return None;
+        }
+        if let Some(node) = self.get_node(&NodeId::new(query)) {
+            return Some((node, "exact_id".into(), true));
+        }
+        if query.contains('/') || query.contains('\\') || query.contains('.') {
+            let file_id = NodeId::from_file_path(&query.replace('\\', "/"));
+            if let Some(node) = self.get_node(&file_id) {
+                return Some((node, "path".into(), true));
+            }
+        }
+        if let Some((owner, name)) = query.rsplit_once("::") {
+            let owner = owner.trim();
+            let name = name.trim();
+            if !owner.is_empty() && !name.is_empty() {
+                if let Some(node) = self
+                    .resolve_unique(name, Some(owner))
+                    .and_then(|id| self.get_node(&id))
+                {
+                    return Some((node, "exact_name".into(), true));
+                }
+            }
+        }
+        let hits = self.search_symbols(query, 8);
+        let best = hits.first()?;
+        let node = self.get_node(&best.id)?;
+        let reliable = matches!(
+            best.match_reason.as_str(),
+            "exact_name" | "prefix" | "exact_id"
+        ) || (best.match_reason == "path"
+            && (query.contains('/') || query.contains('\\') || query.contains('.')));
+        let reason = if reliable {
+            best.match_reason.clone()
+        } else {
+            "fuzzy".into()
+        };
+        Some((node, reason, reliable))
+    }
+
+    /// Re-apply persisted episodic feedback after a cold process start.
+    pub fn replay_learning_paths(&self, paths: &[(&[NodeId], bool)]) {
+        for (node_ids, success) in paths {
+            if node_ids.is_empty() {
+                continue;
+            }
+            for node_id in *node_ids {
+                if self.get_node(node_id).is_some() {
+                    self.reinforce_node_access(node_id, *success);
+                    self.record_neural_spike(node_id.clone(), true, *success);
+                }
+            }
+            self.apply_stdp_on_path(node_ids);
+            self.reinforce_path(node_ids, *success);
+            self.reinforce_callee_edges(node_ids, *success);
         }
     }
 
@@ -2442,11 +2541,50 @@ fn structural_digest(snapshot: &GraphSnapshot) -> String {
         .map(|(k, v)| format!("{k}={v}"))
         .collect();
     hashes.sort();
+    let mut learning: Vec<String> = snapshot
+        .nodes
+        .iter()
+        .map(|n| {
+            format!(
+                "{}:{}:{:.4}",
+                n.id.as_str(),
+                n.access_count,
+                n.base_relevance
+            )
+        })
+        .collect();
+    learning.sort();
+    let mut edge_learning: Vec<String> = snapshot
+        .edges
+        .iter()
+        .map(|e| {
+            format!(
+                "{}:{:.4}:{}",
+                e.id.as_str(),
+                e.pheromone_weight,
+                e.reinforcement_count
+            )
+        })
+        .collect();
+    edge_learning.sort();
     let payload = format!(
-        "{}|{}|{}",
+        "{}|{}|{}|{}|{}",
         node_ids.join("\n"),
         edge_ids.join("\n"),
-        hashes.join("\n")
+        hashes.join("\n"),
+        learning.join("\n"),
+        edge_learning.join("\n")
     );
     neuromesh_index::ContentHasher::hash_str(&payload)
+}
+
+fn pinia_store_type_from_alias(alias: &str) -> String {
+    let alias = alias.trim();
+    if alias.is_empty() {
+        return String::new();
+    }
+    let mut chars = alias.chars();
+    let first = chars.next().unwrap().to_uppercase().collect::<String>();
+    let rest = chars.as_str();
+    format!("use{first}{rest}Store")
 }

--- a/crates/neuromesh-graph/src/quality_tests.rs
+++ b/crates/neuromesh-graph/src/quality_tests.rs
@@ -1614,4 +1614,125 @@ class Greeter {
                 .collect::<Vec<_>>()
         );
     }
+
+    #[test]
+    fn learning_weights_persist_in_graph_snapshot() {
+        let dir = std::env::temp_dir().join(format!("neuromesh-learn-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("graph.bin");
+        let graph = NeuralProjectGraph::new(neuromesh_core::ProjectId::new("persist"));
+        let file = IndexedFile {
+            project_id: neuromesh_core::ProjectId::new("persist"),
+            relative_path: std::path::PathBuf::from("src/a.rs"),
+            full_path: dir.join("src/a.rs"),
+            blake3_hash: "h1".into(),
+            byte_size: 10,
+            token_count: 10,
+            language: neuromesh_index::SourceLanguage::Rust,
+            last_modified: chrono::Utc::now(),
+        };
+        let ast = neuromesh_parser::CodeIntelligenceEngine::analyze(
+            &file.relative_path,
+            "pub fn touched() {}",
+            file.language,
+        );
+        graph.ingest_file(&file, &ast, Some("pub fn touched() {}"));
+        graph.finalize_links();
+        let node = graph.resolve_best("touched").expect("node");
+        graph.reinforce_node_access(&node.id, true);
+        let before = graph
+            .node_learning_profile("touched")
+            .expect("profile")
+            .access_count;
+        assert!(before > 0);
+        graph.save_to(&path).expect("save");
+        let reloaded = NeuralProjectGraph::new(neuromesh_core::ProjectId::new("persist"));
+        assert!(reloaded.load_from(&path).expect("load"));
+        let after = reloaded
+            .node_learning_profile("touched")
+            .expect("profile")
+            .access_count;
+        assert_eq!(
+            after, before,
+            "learning weights must survive snapshot round-trip"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn vue_template_callers_trace_to_store_action() {
+        let graph = NeuralProjectGraph::new(neuromesh_core::ProjectId::new("vue-trace"));
+        let ui_src = r#"import { defineStore } from 'pinia'
+export const useUiStore = defineStore('ui', {
+  actions: { goCheckout() {} },
+})"#;
+        let drawer_src = r#"<script setup>
+import { useUiStore } from '../stores/ui'
+const ui = useUiStore()
+</script>
+<template>
+  <button @click="ui.goCheckout()">Checkout</button>
+</template>"#;
+        ingest_fixture(
+            &graph,
+            "src/stores/ui.js",
+            ui_src,
+            neuromesh_index::SourceLanguage::JavaScript,
+        );
+        ingest_fixture(
+            &graph,
+            "src/components/CartDrawer.vue",
+            drawer_src,
+            neuromesh_index::SourceLanguage::Vue,
+        );
+        graph.finalize_links();
+        let trace = graph.trace_symbol("goCheckout", crate::TraceDirection::Inbound, 2);
+        assert!(trace.origin_reliable, "goCheckout must resolve exactly");
+        assert!(
+            trace.callers.iter().any(|h| h.name == "CartDrawer"),
+            "expected CartDrawer caller, callers={:?}",
+            trace.callers
+        );
+    }
+
+    #[test]
+    fn trace_marks_fuzzy_symbol_origin_unreliable() {
+        let graph = NeuralProjectGraph::new(neuromesh_core::ProjectId::new("fuzzy"));
+        ingest_fixture(
+            &graph,
+            "src/views/CartView.vue",
+            "<template><div /></template>",
+            neuromesh_index::SourceLanguage::Vue,
+        );
+        graph.finalize_links();
+        let trace = graph.trace_symbol("goCart", crate::TraceDirection::Inbound, 2);
+        if let Some(origin) = &trace.origin {
+            assert!(
+                !trace.origin_reliable,
+                "missing symbols must not look like exact trace hits"
+            );
+            assert_eq!(origin.match_reason, "fuzzy");
+        }
+    }
+
+    fn ingest_fixture(
+        graph: &NeuralProjectGraph,
+        rel: &str,
+        src: &str,
+        language: neuromesh_index::SourceLanguage,
+    ) {
+        let file = IndexedFile {
+            project_id: neuromesh_core::ProjectId::new("fixture"),
+            relative_path: std::path::PathBuf::from(rel),
+            full_path: std::path::PathBuf::from(rel),
+            blake3_hash: rel.to_string(),
+            byte_size: src.len() as u64,
+            token_count: 40,
+            language,
+            last_modified: chrono::Utc::now(),
+        };
+        let ast =
+            neuromesh_parser::CodeIntelligenceEngine::analyze(&file.relative_path, src, language);
+        graph.ingest_file(&file, &ast, Some(src));
+    }
 }

--- a/crates/neuromesh-graph/src/query.rs
+++ b/crates/neuromesh-graph/src/query.rs
@@ -58,9 +58,16 @@ pub struct TraceHop {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceResult {
     pub origin: Option<SearchHit>,
+    /// False when the origin was resolved via substring/token/path fuzzy match.
+    #[serde(default = "default_origin_reliable")]
+    pub origin_reliable: bool,
     pub hops: Vec<TraceHop>,
     pub callers: Vec<SearchHit>,
     pub callees: Vec<SearchHit>,
+}
+
+fn default_origin_reliable() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/neuromesh-mcp/src/learning.rs
+++ b/crates/neuromesh-mcp/src/learning.rs
@@ -1,0 +1,23 @@
+use neuromesh_core::{NodeId, ProjectId, Result};
+use neuromesh_graph::NeuralProjectGraph;
+use neuromesh_memory::{replay_unapplied_episodes, LearningReplayTarget, MemoryDatabase};
+
+struct GraphLearning<'a>(&'a NeuralProjectGraph);
+
+impl LearningReplayTarget for GraphLearning<'_> {
+    fn node_access_count(&self, id: &NodeId) -> Option<u64> {
+        self.0.get_node(id).map(|node| node.access_count)
+    }
+
+    fn replay_learning_paths(&self, paths: &[(&[NodeId], bool)]) {
+        NeuralProjectGraph::replay_learning_paths(self.0, paths);
+    }
+}
+
+pub fn warmup_project_learning(
+    memory_db: &MemoryDatabase,
+    graph: &NeuralProjectGraph,
+    project_id: &ProjectId,
+) -> Result<usize> {
+    replay_unapplied_episodes(memory_db, &GraphLearning(graph), project_id)
+}

--- a/crates/neuromesh-mcp/src/lib.rs
+++ b/crates/neuromesh-mcp/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod descriptors;
+pub mod learning;
 pub mod packet_cache;
 pub mod protocol;
 pub mod response;
@@ -7,6 +8,7 @@ pub mod stdio;
 pub mod tools;
 pub mod uri;
 
+pub use learning::warmup_project_learning;
 pub use server::{JsonRpcRequest, McpServer};
 pub use stdio::read_message;
 pub use tools::McpToolHandler;

--- a/crates/neuromesh-mcp/src/server.rs
+++ b/crates/neuromesh-mcp/src/server.rs
@@ -126,6 +126,7 @@ impl McpServer {
         let pid = neuromesh_core::ProjectId::new(&p_name);
         self.handler.graph().set_project_id(pid.clone());
         let _ = self.handler.graph().load_persisted(&p_buf);
+        self.handler.warmup_persisted_learning();
         if self.handler.graph().stats().total_nodes == 0 {
             self.handler.graph().mark_index_loading();
         }

--- a/crates/neuromesh-mcp/src/tools.rs
+++ b/crates/neuromesh-mcp/src/tools.rs
@@ -82,6 +82,11 @@ impl McpToolHandler {
         &self.graph
     }
 
+    pub fn warmup_persisted_learning(&self) {
+        let pid = self.graph.project_id();
+        let _ = crate::learning::warmup_project_learning(&self.memory_db, &self.graph, &pid);
+    }
+
     pub fn mycelium_stats(&self) -> MyceliumStats {
         self.mycelium.stats()
     }

--- a/crates/neuromesh-memory/src/db.rs
+++ b/crates/neuromesh-memory/src/db.rs
@@ -3,7 +3,7 @@ use crate::project::ProjectFact;
 use neuromesh_core::{ProjectId, Result};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -12,6 +12,8 @@ use std::sync::Arc;
 struct StorageData {
     project_facts: HashMap<String, ProjectFact>,
     episodes: Vec<EpisodicRecord>,
+    #[serde(default)]
+    replayed_episode_ids: HashSet<String>,
 }
 
 pub struct MemoryDatabase {
@@ -79,6 +81,43 @@ impl MemoryDatabase {
         self.data.write().episodes.push(record.clone());
         self.persist()?;
         Ok(())
+    }
+
+    pub fn list_project_episodes(&self, project_id: &ProjectId) -> Result<Vec<EpisodicRecord>> {
+        let data = self.data.read();
+        let mut episodes: Vec<EpisodicRecord> = data
+            .episodes
+            .iter()
+            .filter(|e| e.project_id == *project_id)
+            .cloned()
+            .collect();
+        episodes.sort_by_key(|e| e.created_at);
+        Ok(episodes)
+    }
+
+    pub fn unreplayed_episodes(&self, project_id: &ProjectId) -> Result<Vec<EpisodicRecord>> {
+        let data = self.data.read();
+        let mut episodes: Vec<EpisodicRecord> = data
+            .episodes
+            .iter()
+            .filter(|e| e.project_id == *project_id && !data.replayed_episode_ids.contains(&e.id))
+            .cloned()
+            .collect();
+        episodes.sort_by_key(|e| e.created_at);
+        Ok(episodes)
+    }
+
+    pub fn mark_episodes_replayed(&self, episode_ids: &[String]) -> Result<()> {
+        if episode_ids.is_empty() {
+            return Ok(());
+        }
+        {
+            let mut data = self.data.write();
+            for id in episode_ids {
+                data.replayed_episode_ids.insert(id.clone());
+            }
+        }
+        self.persist()
     }
 
     pub fn find_similar_episodes(

--- a/crates/neuromesh-memory/src/lib.rs
+++ b/crates/neuromesh-memory/src/lib.rs
@@ -3,11 +3,16 @@ pub mod db;
 pub mod episodic;
 pub mod extract;
 pub mod project;
+pub mod replay;
 pub mod working;
+
+#[cfg(test)]
+mod replay_tests;
 
 pub use collective::{CollectiveMemory, CollectivePattern};
 pub use db::MemoryDatabase;
 pub use episodic::EpisodicRecord;
 pub use extract::extract_project_facts;
 pub use project::ProjectFact;
+pub use replay::{replay_unapplied_episodes, LearningReplayTarget};
 pub use working::{ToolResultSnippet, WorkingMemory};

--- a/crates/neuromesh-memory/src/replay.rs
+++ b/crates/neuromesh-memory/src/replay.rs
@@ -1,0 +1,38 @@
+use crate::db::MemoryDatabase;
+use neuromesh_core::{NodeId, ProjectId, Result};
+
+/// Replay episodic feedback that was recorded but not yet reflected in the graph snapshot.
+pub fn replay_unapplied_episodes<G>(
+    memory_db: &MemoryDatabase,
+    graph: &G,
+    project_id: &ProjectId,
+) -> Result<usize>
+where
+    G: LearningReplayTarget,
+{
+    let episodes = memory_db.unreplayed_episodes(project_id)?;
+    if episodes.is_empty() {
+        return Ok(0);
+    }
+    let mut replayed_ids = Vec::new();
+    for episode in &episodes {
+        let needs_replay = episode.activated_node_ids.iter().any(|id| {
+            graph
+                .node_access_count(id)
+                .map(|count| count == 0)
+                .unwrap_or(false)
+        });
+        if needs_replay {
+            graph
+                .replay_learning_paths(&[(episode.activated_node_ids.as_slice(), episode.success)]);
+        }
+        replayed_ids.push(episode.id.clone());
+    }
+    memory_db.mark_episodes_replayed(&replayed_ids)?;
+    Ok(replayed_ids.len())
+}
+
+pub trait LearningReplayTarget {
+    fn node_access_count(&self, id: &NodeId) -> Option<u64>;
+    fn replay_learning_paths(&self, paths: &[(&[NodeId], bool)]);
+}

--- a/crates/neuromesh-memory/src/replay_tests.rs
+++ b/crates/neuromesh-memory/src/replay_tests.rs
@@ -1,0 +1,96 @@
+#[cfg(test)]
+mod tests {
+    use crate::db::MemoryDatabase;
+    use crate::episodic::EpisodicRecord;
+    use crate::replay::{replay_unapplied_episodes, LearningReplayTarget};
+    use neuromesh_core::{NodeId, ProjectId};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    struct FakeGraph {
+        access: Mutex<HashMap<String, u64>>,
+        replayed: Mutex<Vec<(Vec<NodeId>, bool)>>,
+    }
+
+    impl FakeGraph {
+        fn new() -> Self {
+            Self {
+                access: Mutex::new(HashMap::new()),
+                replayed: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl LearningReplayTarget for FakeGraph {
+        fn node_access_count(&self, id: &NodeId) -> Option<u64> {
+            Some(*self.access.lock().unwrap().get(id.as_str()).unwrap_or(&0))
+        }
+
+        fn replay_learning_paths(&self, paths: &[(&[NodeId], bool)]) {
+            let mut replayed = self.replayed.lock().unwrap();
+            for (ids, success) in paths {
+                replayed.push((ids.to_vec(), *success));
+                let mut access = self.access.lock().unwrap();
+                for id in *ids {
+                    *access.entry(id.as_str().to_string()).or_insert(0) += 1;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn replay_skips_episodes_already_reflected_in_graph() {
+        let db = MemoryDatabase::open_in_memory().unwrap();
+        let graph = FakeGraph::new();
+        let pid = ProjectId::new("shop");
+        let node = NodeId::new("src/CheckoutView.vue");
+        graph
+            .access
+            .lock()
+            .unwrap()
+            .insert(node.as_str().to_string(), 3);
+        let episode = EpisodicRecord::new(
+            pid.clone(),
+            "hash".into(),
+            "checkout".into(),
+            "ok".into(),
+            vec![node.clone()],
+            vec!["CheckoutView".into()],
+            true,
+            0,
+        );
+        db.save_episodic_record(&episode).unwrap();
+        let replayed = replay_unapplied_episodes(&db, &graph, &pid).unwrap();
+        assert_eq!(replayed, 1);
+        assert!(
+            graph.replayed.lock().unwrap().is_empty(),
+            "already-learned nodes must not be replayed"
+        );
+    }
+
+    #[test]
+    fn replay_applies_unreplayed_episode_when_graph_is_cold() {
+        let db = MemoryDatabase::open_in_memory().unwrap();
+        let graph = FakeGraph::new();
+        let pid = ProjectId::new("shop");
+        let node = NodeId::new("src/CheckoutView.vue");
+        let episode = EpisodicRecord::new(
+            pid.clone(),
+            "hash".into(),
+            "checkout".into(),
+            "ok".into(),
+            vec![node.clone()],
+            vec!["CheckoutView".into()],
+            true,
+            0,
+        );
+        db.save_episodic_record(&episode).unwrap();
+        let replayed = replay_unapplied_episodes(&db, &graph, &pid).unwrap();
+        assert_eq!(replayed, 1);
+        assert_eq!(graph.replayed.lock().unwrap().len(), 1);
+        assert_eq!(
+            graph.access.lock().unwrap().get(node.as_str()).copied(),
+            Some(1)
+        );
+    }
+}

--- a/crates/neuromesh-parser/src/typescript.rs
+++ b/crates/neuromesh-parser/src/typescript.rs
@@ -73,8 +73,9 @@ impl TypeScriptParser {
 
         for cap in pinia_regex.captures_iter(content) {
             if let Some(store_name) = cap.get(1) {
+                let store = store_name.as_str().to_string();
                 result.symbols.push(ParsedSymbol::new(
-                    store_name.as_str(),
+                    &store,
                     NodeType::Component,
                     Some(format!(
                         "defineStore('{}')",
@@ -83,6 +84,7 @@ impl TypeScriptParser {
                     1..content.lines().count() + 1,
                     true,
                 ));
+                collect_pinia_actions(content, &store, &mut result);
             }
         }
 
@@ -204,6 +206,44 @@ impl TypeScriptParser {
     }
 }
 
+fn collect_pinia_actions(content: &str, store_name: &str, result: &mut AstAnalysisResult) {
+    let action_method_re = Regex::new(r"^\s+(?:async\s+)?(\w+)\s*\([^)]*\)\s*\{").unwrap();
+    let mut in_actions = false;
+    let mut depth = 0i32;
+    for (line_idx, line) in content.lines().enumerate() {
+        if !in_actions {
+            if line.contains("actions") && line.contains('{') {
+                in_actions = true;
+                depth = brace_delta(line);
+            }
+            continue;
+        }
+        depth += brace_delta(line);
+        if let Some(cap) = action_method_re.captures(line) {
+            if let Some(name) = cap.get(1) {
+                let action = name.as_str();
+                if matches!(action, "state" | "getters" | "actions") {
+                    continue;
+                }
+                result.symbols.push({
+                    let mut sym = ParsedSymbol::new(
+                        action,
+                        NodeType::Function,
+                        Some(format!("{store_name}.{action}()")),
+                        (line_idx + 1)..(line_idx + 2),
+                        false,
+                    );
+                    sym.parent = Some(store_name.to_string());
+                    sym
+                });
+            }
+        }
+        if depth <= 0 {
+            in_actions = false;
+        }
+    }
+}
+
 fn asset_import_label(source: &str) -> String {
     Path::new(source)
         .file_stem()
@@ -305,5 +345,36 @@ fn collect_cjs_requires(result: &mut AstAnalysisResult, filename: &str, content:
                 result.exports.push(name.to_string());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pinia_actions_become_function_symbols_with_parent() {
+        let src = r#"import { defineStore } from 'pinia'
+
+export const useUiStore = defineStore('ui', {
+  actions: {
+    goCheckout() {
+      this.currentView = 'checkout'
+    },
+    showToast(message) {
+      this.toast = message
+    },
+  },
+})
+"#;
+        let ast = TypeScriptParser::parse(std::path::Path::new("src/stores/ui.js"), src);
+        assert!(
+            ast.symbols
+                .iter()
+                .any(|s| { s.name == "goCheckout" && s.parent.as_deref() == Some("useUiStore") }),
+            "symbols={:?}",
+            ast.symbols
+        );
+        assert!(ast.symbols.iter().any(|s| s.name == "showToast"));
     }
 }

--- a/crates/neuromesh-parser/src/vue.rs
+++ b/crates/neuromesh-parser/src/vue.rs
@@ -140,18 +140,14 @@ impl VueParser {
             }
         }
         let handler_regex =
-            Regex::new(r#"(?:@click|@submit|v-on:click|v-on:submit)\s*=\s*["']([^"']+)["']"#)
+            Regex::new(r#"(?:@[A-Za-z][\w:.$-]*|v-on:[A-Za-z][\w:.$-]*)\s*=\s*["']([^"']+)["']"#)
                 .unwrap();
         let action_call_regex = Regex::new(r"(\w+)\.(\w+)\s*\(").unwrap();
-        for cap in handler_regex.captures_iter(content) {
-            let Some(expr) = cap.get(1) else {
-                continue;
-            };
-            let Some(am) = action_call_regex.captures(expr.as_str()) else {
-                continue;
-            };
-            let alias = am.get(1).map(|m| m.as_str()).unwrap_or("");
-            let action = am.get(2).map(|m| m.as_str()).unwrap_or("");
+        let action_ref_regex = Regex::new(r"^(\w+)\.(\w+)$").unwrap();
+        let push_store_action = |alias: &str, action: &str, result: &mut AstAnalysisResult| {
+            if action.is_empty() || !store_aliases.contains_key(alias) {
+                return;
+            }
             result.relationships.push(ParsedRelationship {
                 source_symbol: filename.to_string(),
                 target_symbol: action.to_string(),
@@ -159,6 +155,35 @@ impl VueParser {
                 target_file_hint: store_aliases.get(alias).cloned(),
                 receiver_hint: Some(alias.to_string()),
             });
+        };
+        for cap in handler_regex.captures_iter(content) {
+            let Some(expr) = cap.get(1) else {
+                continue;
+            };
+            let expr = expr.as_str().trim();
+            if let Some(am) = action_call_regex.captures(expr) {
+                push_store_action(
+                    am.get(1).map(|m| m.as_str()).unwrap_or(""),
+                    am.get(2).map(|m| m.as_str()).unwrap_or(""),
+                    &mut result,
+                );
+            } else if let Some(am) = action_ref_regex.captures(expr) {
+                push_store_action(
+                    am.get(1).map(|m| m.as_str()).unwrap_or(""),
+                    am.get(2).map(|m| m.as_str()).unwrap_or(""),
+                    &mut result,
+                );
+            }
+        }
+
+        if let Some(script) = extract_script_block(content) {
+            for am in action_call_regex.captures_iter(script) {
+                push_store_action(
+                    am.get(1).map(|m| m.as_str()).unwrap_or(""),
+                    am.get(2).map(|m| m.as_str()).unwrap_or(""),
+                    &mut result,
+                );
+            }
         }
 
         // 5. Extract SCSS @use / @import / Design tokens from <style>
@@ -226,10 +251,19 @@ fn pinia_store_hint(hook: &str) -> String {
         }
     }
     if out.is_empty() {
-        format!("{hook}.ts")
+        hook.to_string()
     } else {
-        format!("stores/{out}.ts")
+        format!("stores/{out}")
     }
+}
+
+fn extract_script_block(content: &str) -> Option<&str> {
+    let open = content.find("<script")?;
+    let after_open = &content[open..];
+    let start = after_open.find('>')? + 1;
+    let body = &after_open[start..];
+    let end = body.find("</script>")?;
+    Some(&body[..end])
 }
 
 fn vue_tag_to_component(tag: &str) -> String {
@@ -360,9 +394,48 @@ const ui = useUiStore()
             ast.relationships.iter().any(|r| {
                 r.target_symbol == "goCart"
                     && r.relationship == EdgeType::Calls
-                    && r.target_file_hint.as_deref() == Some("stores/ui.ts")
+                    && r.target_file_hint.as_deref() == Some("stores/ui")
             }),
             "expected goCart call edge, rels={:?}",
+            ast.relationships
+        );
+    }
+
+    #[test]
+    fn template_view_binding_extracts_store_action_call() {
+        let src = r#"<script setup>
+const products = useProductsStore()
+</script>
+<template>
+  <ProductGrid @view="products.openProduct" />
+</template>
+"#;
+        let ast = VueParser::parse(std::path::Path::new("App.vue"), src);
+        assert!(
+            ast.relationships.iter().any(|r| {
+                r.target_symbol == "openProduct"
+                    && r.relationship == EdgeType::Calls
+                    && r.receiver_hint.as_deref() == Some("products")
+            }),
+            "expected openProduct call edge, rels={:?}",
+            ast.relationships
+        );
+    }
+
+    #[test]
+    fn script_setup_extracts_store_action_call() {
+        let src = r#"<script setup>
+const ui = useUiStore()
+ui.showToast('saved')
+</script>
+<template><div /></template>
+"#;
+        let ast = VueParser::parse(std::path::Path::new("CheckoutView.vue"), src);
+        assert!(
+            ast.relationships
+                .iter()
+                .any(|r| { r.target_symbol == "showToast" && r.relationship == EdgeType::Calls }),
+            "expected showToast call edge, rels={:?}",
             ast.relationships
         );
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes live here. The README stays a product guide, not
 
 ## Unreleased
 
+## 0.7.8 — 2026-08-28
+
+RETEST v0.7.7 follow-up: cross-session learning, Vue trace edges, and honest fuzzy trace.
+
+- **Learning persistence.** `graph.bin` snapshot digest now includes `access_count`, `base_relevance`, and edge pheromone weights so `save_persisted` after `record_feedback` is not skipped as “structurally unchanged”. Episodes replay on MCP startup when graph nodes are still cold (`warmup_project_learning`).
+- **Vue trace / dead-code.** Pinia `actions` methods become `Function` symbols; template `@click` / `@view` and `<script setup>` store calls emit `Calls` edges; store file hints are extension-agnostic (`stores/ui` resolves `ui.js`). `trace` inbound callers work for `goCheckout` and similar.
+- **Trace honesty.** `TraceResult.origin_reliable` and `match_reason: "fuzzy"` when the seed is not an exact/prefix hit — agents must not treat fuzzy origins as dead-code proof.
+- **Pinia alias resolve.** Store alias `ui` maps to `useUiStore::action` during call linking.
+
 ## 0.7.7 — 2026-08-28
 
 Benchmark-driven routing, honest coverage, and a falsifiable learning loop (Vue shop fixture).

--- a/editors/vscode-neuromesh/README.md
+++ b/editors/vscode-neuromesh/README.md
@@ -2,7 +2,7 @@
 
 Sidebar mesh stats, a packet inspector, fold CodeLens, and the galaxy UI — talking to a running `neuromesh monitor`.
 
-The agent loop in the editor matches 0.7.7: **get_context → expand_fold** (or **expand_gap** for `packet_gaps`). Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**; use **get_node_weights** to verify learning deltas.
+The agent loop in the editor matches 0.7.8: **get_context → expand_fold** (or **expand_gap** for `packet_gaps`). Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**; use **get_node_weights** to verify learning deltas.
 
 ## Install
 

--- a/editors/vscode-neuromesh/package.json
+++ b/editors/vscode-neuromesh/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-neuromesh",
   "displayName": "NeuroMesh",
   "description": "Evidence packets, reversible folds, and a live mesh sidebar for Cursor & VS Code. Don’t dump files — fold them.",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "publisher": "neuromesh",
   "license": "MIT",
   "homepage": "https://github.com/pinoox/neuromesh",


### PR DESCRIPTION
RETEST v0.7.7 follow-up: cross-session learning, Vue trace edges, and honest fuzzy trace.

- **Learning persistence.** `graph.bin` snapshot digest now includes `access_count`, `base_relevance`, and edge pheromone weights so `save_persisted` after `record_feedback` is not skipped as “structurally unchanged”. Episodes replay on MCP startup when graph nodes are still cold (`warmup_project_learning`).
- **Vue trace / dead-code.** Pinia `actions` methods become `Function` symbols; template `@click` / `@view` and `<script setup>` store calls emit `Calls` edges; store file hints are extension-agnostic (`stores/ui` resolves `ui.js`). `trace` inbound callers work for `goCheckout` and similar.
- **Trace honesty.** `TraceResult.origin_reliable` and `match_reason: "fuzzy"` when the seed is not an exact/prefix hit — agents must not treat fuzzy origins as dead-code proof.
- **Pinia alias resolve.** Store alias `ui` maps to `useUiStore::action` during call linking.
