### PR TITLE
Fix durable learning persistence and parser epoch relink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-api"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "futures-util",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cache"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cli"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-context"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-core"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-graph"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "bincode",
  "chrono",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-index"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "blake3",
  "chrono",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-local-ai"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "neuromesh-core",
  "parking_lot",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-mcp"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "neuromesh-cache",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-memory"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-observability"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-parser"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "neuromesh-core",
  "neuromesh-index",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-provider"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "futures-util",
  "neuromesh-core",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-router"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "neuromesh-context",
  "neuromesh-core",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-task"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "neuromesh-core",
  "neuromesh-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 exclude = ["tests/fixtures/mini-axum"]
 
 [workspace.package]
-version = "0.7.8"
+version = "0.7.9"
 edition = "2021"
 rust-version = "1.80"
 authors = ["NeuroMesh Team <team@neuromesh.local>"]

--- a/README.md
+++ b/README.md
@@ -318,6 +318,6 @@ Index snapshot from that eval run: **323 files · 2,458 nodes · 5,594 edges · 
 | [MCP](docs/mcp.md) · [CLI](docs/cli.md) | Tools and commands |
 | [Quality](docs/quality.md) | Gold, eval, numbers |
 | [Contributing](docs/contributing.md) | Come build a solver or a language |
-| [Changelog](docs/CHANGELOG.md) | 0.7.8 |
+| [Changelog](docs/CHANGELOG.md) | 0.7.9 |
 
 MIT · [LICENSE](LICENSE)

--- a/crates/neuromesh-context/src/style_routing.rs
+++ b/crates/neuromesh-context/src/style_routing.rs
@@ -205,8 +205,8 @@ pub(crate) fn tighten_focused_view_selection(
         return;
     }
     let keep = |path: &str| {
-        let p = path.to_lowercase();
-        p.contains("checkoutview") || p.contains("/stores/cart")
+        let p = path.replace('\\', "/").to_lowercase();
+        p.contains("checkoutview") || p.contains("stores/cart")
     };
     selection.optional.retain(|id| {
         graph
@@ -217,10 +217,7 @@ pub(crate) fn tighten_focused_view_selection(
     selection.required.retain(|id| {
         graph
             .get_node(id)
-            .map(|n| {
-                let p = n.file_path.to_string_lossy().to_lowercase();
-                keep(&p) || p.contains("/stores/cart")
-            })
+            .map(|n| keep(&n.file_path.to_string_lossy()))
             .unwrap_or(true)
     });
 }

--- a/crates/neuromesh-graph/src/graph.rs
+++ b/crates/neuromesh-graph/src/graph.rs
@@ -28,6 +28,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+/// Bump when parser/linker output changes; older snapshots re-parse on load.
+pub const GRAPH_PARSER_EPOCH: u32 = 3;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GraphStats {
     pub total_nodes: usize,
@@ -1385,12 +1388,46 @@ impl NeuralProjectGraph {
         self.save_to(&Self::persist_path(workspace))
     }
 
+    pub fn save_persisted_if_ready(&self) -> neuromesh_core::Result<()> {
+        if let Some(workspace) = self.persist_workspace() {
+            self.save_persisted(&workspace)?;
+        }
+        Ok(())
+    }
+
     pub fn set_workspace(&self, workspace: &Path) {
         self.inner.write().workspace_root = Some(workspace.to_path_buf());
     }
 
     pub fn workspace_root(&self) -> Option<PathBuf> {
         self.inner.read().workspace_root.clone()
+    }
+
+    /// Workspace directory for graph/memory persistence (never silently use wrong cwd).
+    pub fn persist_workspace(&self) -> Option<PathBuf> {
+        self.workspace_root()
+    }
+
+    pub fn parser_epoch(&self) -> u32 {
+        self.inner.read().parser_epoch
+    }
+
+    pub fn learning_episode_applied(&self, episode_id: &str) -> bool {
+        self.inner
+            .read()
+            .applied_learning_episodes
+            .contains(episode_id)
+    }
+
+    pub fn mark_learning_episode_applied(&self, episode_id: &str) {
+        self.inner
+            .write()
+            .applied_learning_episodes
+            .insert(episode_id.to_string());
+    }
+
+    pub fn needs_parser_relink(&self) -> bool {
+        self.parser_epoch() < GRAPH_PARSER_EPOCH
     }
 
     pub fn file_fingerprints(&self) -> HashMap<String, FileFingerprint> {
@@ -1440,6 +1477,7 @@ impl NeuralProjectGraph {
         match walker.scan_report_with(&self.file_fingerprints()) {
             Ok(report) => {
                 self.ingest_scan_report(&report);
+                self.inner.write().parser_epoch = GRAPH_PARSER_EPOCH;
                 let _ = self.save_persisted(workspace);
                 self.mark_index_ready();
             }
@@ -1543,7 +1581,7 @@ impl NeuralProjectGraph {
         let snapshot = {
             let data = self.inner.read();
             GraphSnapshot {
-                version: 2,
+                version: 3,
                 nodes: data
                     .mesh
                     .nodes()
@@ -1559,6 +1597,8 @@ impl NeuralProjectGraph {
                 indexed_at: data.indexed_at,
                 stale_files: data.stale_files.clone(),
                 workspace_root: data.workspace_root.clone(),
+                parser_epoch: data.parser_epoch.max(GRAPH_PARSER_EPOCH),
+                applied_learning_episodes: data.applied_learning_episodes.clone(),
             }
         };
         if snapshot_structurally_unchanged(path, &snapshot) {
@@ -1602,6 +1642,8 @@ impl NeuralProjectGraph {
                 indexed_at: legacy.indexed_at,
                 stale_files: legacy.stale_files,
                 workspace_root: None,
+                parser_epoch: 0,
+                applied_learning_episodes: HashSet::new(),
             });
             return Ok(true);
         }
@@ -1609,6 +1651,7 @@ impl NeuralProjectGraph {
     }
 
     fn install_snapshot(&self, snapshot: GraphSnapshot) {
+        let relink_needed = snapshot.parser_epoch < GRAPH_PARSER_EPOCH;
         let mut data = self.inner.write();
         data.mesh.load_lists(snapshot.nodes, snapshot.edges);
         data.pending = snapshot.pending;
@@ -1619,8 +1662,14 @@ impl NeuralProjectGraph {
         data.generation = snapshot.generation;
         data.indexed_at = snapshot.indexed_at;
         data.stale_files = snapshot.stale_files;
+        data.applied_learning_episodes = snapshot.applied_learning_episodes;
+        data.parser_epoch = snapshot.parser_epoch;
         if snapshot.workspace_root.is_some() {
             data.workspace_root = snapshot.workspace_root;
+        }
+        if relink_needed {
+            data.file_hashes.clear();
+            data.parser_epoch = 0;
         }
         data.source_overlay.clear();
         rebuild_indexes(&mut data);
@@ -2567,13 +2616,17 @@ fn structural_digest(snapshot: &GraphSnapshot) -> String {
         })
         .collect();
     edge_learning.sort();
+    let mut applied: Vec<String> = snapshot.applied_learning_episodes.iter().cloned().collect();
+    applied.sort();
     let payload = format!(
-        "{}|{}|{}|{}|{}",
+        "{}|{}|{}|{}|{}|{}|{}",
         node_ids.join("\n"),
         edge_ids.join("\n"),
         hashes.join("\n"),
         learning.join("\n"),
-        edge_learning.join("\n")
+        edge_learning.join("\n"),
+        applied.join("\n"),
+        snapshot.parser_epoch
     );
     neuromesh_index::ContentHasher::hash_str(&payload)
 }

--- a/crates/neuromesh-graph/src/intern.rs
+++ b/crates/neuromesh-graph/src/intern.rs
@@ -1,5 +1,5 @@
 use neuromesh_core::{ContextEdge, ContextNode, EdgeId, NodeId};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Compact interned mesh: nodes and edges live in slot vectors, adjacency is `u32`.
 #[derive(Default)]
@@ -313,7 +313,6 @@ use neuromesh_core::{EdgeType, NodeType, UnresolvedRef};
 use neuromesh_index::{FileFingerprint, IndexedFile};
 use neuromesh_parser::api_path_alias;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Default)]
@@ -333,6 +332,8 @@ pub(crate) struct GraphData {
     pub stale_files: Vec<String>,
     pub workspace_root: Option<PathBuf>,
     pub source_overlay: HashMap<String, String>,
+    pub parser_epoch: u32,
+    pub applied_learning_episodes: HashSet<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -353,6 +354,10 @@ pub(crate) struct GraphSnapshot {
     pub stale_files: Vec<String>,
     #[serde(default)]
     pub workspace_root: Option<PathBuf>,
+    #[serde(default)]
+    pub parser_epoch: u32,
+    #[serde(default)]
+    pub applied_learning_episodes: HashSet<String>,
 }
 
 #[derive(Deserialize)]

--- a/crates/neuromesh-graph/src/lib.rs
+++ b/crates/neuromesh-graph/src/lib.rs
@@ -17,6 +17,7 @@ pub use activation::{SpreadingActivation, SpreadingActivationConfig};
 pub use edge::{PheromoneConfig, PheromoneEngine};
 pub use graph::{
     path_echoes_symbol, GraphStats, IndexState, NeuralProjectGraph, NodeLearningProfile,
+    GRAPH_PARSER_EPOCH,
 };
 pub use node::NodeFactory;
 pub use physarum::{PhysarumConfig, PhysarumResult, PhysarumSolver};

--- a/crates/neuromesh-graph/src/quality_tests.rs
+++ b/crates/neuromesh-graph/src/quality_tests.rs
@@ -1,9 +1,11 @@
 #[cfg(test)]
 mod tests {
+    use crate::intern::GraphSnapshot;
     use crate::NeuralProjectGraph;
     use neuromesh_core::{NodeType, ProjectId};
     use neuromesh_index::{IndexedFile, SourceLanguage};
     use neuromesh_parser::CodeIntelligenceEngine;
+    use std::collections::{HashMap, HashSet};
     use std::path::PathBuf;
     use std::time::Instant;
 
@@ -1656,6 +1658,84 @@ class Greeter {
             after, before,
             "learning weights must survive snapshot round-trip"
         );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn parser_epoch_mismatch_clears_file_hashes_for_relink() {
+        let dir = std::env::temp_dir().join(format!("neuromesh-epoch-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("graph.bin");
+        let snapshot = GraphSnapshot {
+            version: 2,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            pending: Vec::new(),
+            unresolved: Vec::new(),
+            file_hashes: [("src/App.vue".into(), "old-hash".into())]
+                .into_iter()
+                .collect(),
+            file_fingerprints: HashMap::new(),
+            export_index: HashMap::new(),
+            generation: 1,
+            indexed_at: None,
+            stale_files: Vec::new(),
+            workspace_root: Some(dir.clone()),
+            parser_epoch: 0,
+            applied_learning_episodes: HashSet::new(),
+        };
+        let bytes = bincode::serialize(&snapshot).expect("serialize");
+        std::fs::write(&path, bytes).expect("write");
+        let graph = NeuralProjectGraph::new(ProjectId::new("epoch"));
+        assert!(graph.load_from(&path).expect("load"));
+        assert!(graph.needs_parser_relink());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn mini_shop_vue_trace_finds_template_callers() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/mini-shop");
+        if !root.join("src/stores/ui.js").exists() {
+            return;
+        }
+        let graph = NeuralProjectGraph::new(ProjectId::new("mini-shop-trace"));
+        for (rel, lang) in [
+            ("src/stores/ui.js", SourceLanguage::JavaScript),
+            ("src/stores/cart.js", SourceLanguage::JavaScript),
+            ("src/components/Header.vue", SourceLanguage::Vue),
+            ("src/components/CartDrawer.vue", SourceLanguage::Vue),
+        ] {
+            let path = root.join(rel);
+            let src = std::fs::read_to_string(&path).expect("read fixture");
+            ingest_fixture(&graph, rel, &src, lang);
+        }
+        graph.finalize_links();
+        let go_checkout = graph.trace_symbol("goCheckout", crate::TraceDirection::Inbound, 2);
+        assert!(
+            go_checkout.callers.iter().any(|h| h.name == "CartDrawer"),
+            "goCheckout callers={:?}",
+            go_checkout.callers
+        );
+        let go_cart = graph.trace_symbol("goCart", crate::TraceDirection::Inbound, 2);
+        assert!(
+            go_cart.callers.iter().any(|h| h.name == "Header"),
+            "goCart callers={:?}",
+            go_cart.callers
+        );
+    }
+
+    #[test]
+    fn learning_episode_checkpoint_round_trips_in_snapshot() {
+        let dir = std::env::temp_dir().join(format!("neuromesh-ep-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("graph.bin");
+        let graph = NeuralProjectGraph::new(ProjectId::new("ep"));
+        graph.mark_learning_episode_applied("episode-abc");
+        graph.set_workspace(&dir);
+        graph.save_to(&path).expect("save");
+        let reloaded = NeuralProjectGraph::new(ProjectId::new("ep"));
+        assert!(reloaded.load_from(&path).expect("load"));
+        assert!(reloaded.learning_episode_applied("episode-abc"));
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/crates/neuromesh-mcp/src/learning.rs
+++ b/crates/neuromesh-mcp/src/learning.rs
@@ -5,12 +5,20 @@ use neuromesh_memory::{replay_unapplied_episodes, LearningReplayTarget, MemoryDa
 struct GraphLearning<'a>(&'a NeuralProjectGraph);
 
 impl LearningReplayTarget for GraphLearning<'_> {
-    fn node_access_count(&self, id: &NodeId) -> Option<u64> {
-        self.0.get_node(id).map(|node| node.access_count)
+    fn learning_episode_applied(&self, episode_id: &str) -> bool {
+        self.0.learning_episode_applied(episode_id)
+    }
+
+    fn mark_learning_episode_applied(&self, episode_id: &str) {
+        self.0.mark_learning_episode_applied(episode_id);
     }
 
     fn replay_learning_paths(&self, paths: &[(&[NodeId], bool)]) {
         NeuralProjectGraph::replay_learning_paths(self.0, paths);
+    }
+
+    fn persist_replayed_learning(&self) -> Result<()> {
+        self.0.save_persisted_if_ready()
     }
 }
 

--- a/crates/neuromesh-mcp/src/server.rs
+++ b/crates/neuromesh-mcp/src/server.rs
@@ -58,6 +58,7 @@ impl McpServer {
             }
         }
 
+        self.handler.flush_on_shutdown();
         Ok(())
     }
 

--- a/crates/neuromesh-mcp/src/tools.rs
+++ b/crates/neuromesh-mcp/src/tools.rs
@@ -87,6 +87,14 @@ impl McpToolHandler {
         let _ = crate::learning::warmup_project_learning(&self.memory_db, &self.graph, &pid);
     }
 
+    pub fn persist_project_state(&self) {
+        let _ = self.graph.save_persisted_if_ready();
+    }
+
+    pub fn flush_on_shutdown(&self) {
+        self.persist_project_state();
+    }
+
     pub fn mycelium_stats(&self) -> MyceliumStats {
         self.mycelium.stats()
     }
@@ -671,11 +679,9 @@ impl McpToolHandler {
                 self.graph.reinforce_path(&path, success);
                 self.graph.reinforce_callee_edges(&path, success);
                 self.record_mycelium_path(&path);
-                if let Ok(cwd) = std::env::current_dir() {
-                    let _ = self.graph.save_persisted(&cwd);
-                }
 
                 let pid = self.graph.project_id();
+                let mut episode_id = String::new();
                 if !path.is_empty() {
                     let summary = if success {
                         format!("successful edit touching {}", path.len())
@@ -692,8 +698,13 @@ impl McpToolHandler {
                         success,
                         0,
                     );
+                    episode_id = episode.id.clone();
                     let _ = self.memory_db.save_episodic_record(&episode);
                 }
+                if !episode_id.is_empty() {
+                    self.graph.mark_learning_episode_applied(&episode_id);
+                }
+                let _ = self.graph.save_persisted_if_ready();
 
                 self.emit_telemetry(ToolTelemetry {
                     nodes_after: path.len(),

--- a/crates/neuromesh-memory/src/replay.rs
+++ b/crates/neuromesh-memory/src/replay.rs
@@ -1,7 +1,7 @@
 use crate::db::MemoryDatabase;
 use neuromesh_core::{NodeId, ProjectId, Result};
 
-/// Replay episodic feedback that was recorded but not yet reflected in the graph snapshot.
+/// Replay episodic feedback not yet reflected in the graph snapshot.
 pub fn replay_unapplied_episodes<G>(
     memory_db: &MemoryDatabase,
     graph: &G,
@@ -16,15 +16,15 @@ where
     }
     let mut replayed_ids = Vec::new();
     for episode in &episodes {
-        let needs_replay = episode.activated_node_ids.iter().any(|id| {
-            graph
-                .node_access_count(id)
-                .map(|count| count == 0)
-                .unwrap_or(false)
-        });
-        if needs_replay {
+        if graph.learning_episode_applied(&episode.id) {
+            replayed_ids.push(episode.id.clone());
+            continue;
+        }
+        if !episode.activated_node_ids.is_empty() {
             graph
                 .replay_learning_paths(&[(episode.activated_node_ids.as_slice(), episode.success)]);
+            graph.mark_learning_episode_applied(&episode.id);
+            graph.persist_replayed_learning()?;
         }
         replayed_ids.push(episode.id.clone());
     }
@@ -33,6 +33,8 @@ where
 }
 
 pub trait LearningReplayTarget {
-    fn node_access_count(&self, id: &NodeId) -> Option<u64>;
+    fn learning_episode_applied(&self, episode_id: &str) -> bool;
+    fn mark_learning_episode_applied(&self, episode_id: &str);
     fn replay_learning_paths(&self, paths: &[(&[NodeId], bool)]);
+    fn persist_replayed_learning(&self) -> Result<()>;
 }

--- a/crates/neuromesh-memory/src/replay_tests.rs
+++ b/crates/neuromesh-memory/src/replay_tests.rs
@@ -3,52 +3,54 @@ mod tests {
     use crate::db::MemoryDatabase;
     use crate::episodic::EpisodicRecord;
     use crate::replay::{replay_unapplied_episodes, LearningReplayTarget};
-    use neuromesh_core::{NodeId, ProjectId};
-    use std::collections::HashMap;
+    use neuromesh_core::{NodeId, ProjectId, Result};
+    use std::collections::HashSet;
     use std::sync::Mutex;
 
     struct FakeGraph {
-        access: Mutex<HashMap<String, u64>>,
+        applied: Mutex<HashSet<String>>,
         replayed: Mutex<Vec<(Vec<NodeId>, bool)>>,
+        persisted: Mutex<u32>,
     }
 
     impl FakeGraph {
         fn new() -> Self {
             Self {
-                access: Mutex::new(HashMap::new()),
+                applied: Mutex::new(HashSet::new()),
                 replayed: Mutex::new(Vec::new()),
+                persisted: Mutex::new(0),
             }
         }
     }
 
     impl LearningReplayTarget for FakeGraph {
-        fn node_access_count(&self, id: &NodeId) -> Option<u64> {
-            Some(*self.access.lock().unwrap().get(id.as_str()).unwrap_or(&0))
+        fn learning_episode_applied(&self, episode_id: &str) -> bool {
+            self.applied.lock().unwrap().contains(episode_id)
+        }
+
+        fn mark_learning_episode_applied(&self, episode_id: &str) {
+            self.applied.lock().unwrap().insert(episode_id.to_string());
         }
 
         fn replay_learning_paths(&self, paths: &[(&[NodeId], bool)]) {
             let mut replayed = self.replayed.lock().unwrap();
             for (ids, success) in paths {
                 replayed.push((ids.to_vec(), *success));
-                let mut access = self.access.lock().unwrap();
-                for id in *ids {
-                    *access.entry(id.as_str().to_string()).or_insert(0) += 1;
-                }
             }
+        }
+
+        fn persist_replayed_learning(&self) -> Result<()> {
+            *self.persisted.lock().unwrap() += 1;
+            Ok(())
         }
     }
 
     #[test]
-    fn replay_skips_episodes_already_reflected_in_graph() {
+    fn replay_skips_episodes_already_in_graph_checkpoint() {
         let db = MemoryDatabase::open_in_memory().unwrap();
         let graph = FakeGraph::new();
         let pid = ProjectId::new("shop");
         let node = NodeId::new("src/CheckoutView.vue");
-        graph
-            .access
-            .lock()
-            .unwrap()
-            .insert(node.as_str().to_string(), 3);
         let episode = EpisodicRecord::new(
             pid.clone(),
             "hash".into(),
@@ -59,17 +61,18 @@ mod tests {
             true,
             0,
         );
+        graph.mark_learning_episode_applied(&episode.id);
         db.save_episodic_record(&episode).unwrap();
         let replayed = replay_unapplied_episodes(&db, &graph, &pid).unwrap();
         assert_eq!(replayed, 1);
         assert!(
             graph.replayed.lock().unwrap().is_empty(),
-            "already-learned nodes must not be replayed"
+            "checkpointed episodes must not replay"
         );
     }
 
     #[test]
-    fn replay_applies_unreplayed_episode_when_graph_is_cold() {
+    fn replay_applies_unreplayed_episode_and_persists() {
         let db = MemoryDatabase::open_in_memory().unwrap();
         let graph = FakeGraph::new();
         let pid = ProjectId::new("shop");
@@ -88,9 +91,7 @@ mod tests {
         let replayed = replay_unapplied_episodes(&db, &graph, &pid).unwrap();
         assert_eq!(replayed, 1);
         assert_eq!(graph.replayed.lock().unwrap().len(), 1);
-        assert_eq!(
-            graph.access.lock().unwrap().get(node.as_str()).copied(),
-            Some(1)
-        );
+        assert!(graph.learning_episode_applied(&episode.id));
+        assert_eq!(*graph.persisted.lock().unwrap(), 1);
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes live here. The README stays a product guide, not
 
 ## Unreleased
 
+## 0.7.9 — 2026-08-28
+
+durable learning, parser relink, and Vue trace on stale snapshots.
+
+- **Learning persistence (real).** `record_feedback` saves `graph.bin` via `workspace_root` (not MCP `cwd`). Episode IDs are checkpointed in the snapshot (`applied_learning_episodes`). Replay on startup applies only episodes missing from the checkpoint, then persists. MCP flushes graph state on graceful stdio shutdown.
+- **Parser epoch relink.** `GRAPH_PARSER_EPOCH` (3) in snapshots; loading an older epoch clears `file_hashes` so the next index re-parses all files (Vue CALL edges on upgraded installs without manual `--force`).
+- **Windows routing fix.** `tighten_focused_view_selection` normalizes `\` paths so `cart.js` is kept on checkout stepper tasks (gold `checkout_qty_stepper`).
+- **Benchmark fixture.** `ProductGrid.vue` `@view` binding corrected to `ui.openProduct` (action lives in `ui.js`).
+
 ## 0.7.8 — 2026-08-28
 
 RETEST v0.7.7 follow-up: cross-session learning, Vue trace edges, and honest fuzzy trace.

--- a/editors/vscode-neuromesh/README.md
+++ b/editors/vscode-neuromesh/README.md
@@ -2,7 +2,7 @@
 
 Sidebar mesh stats, a packet inspector, fold CodeLens, and the galaxy UI — talking to a running `neuromesh monitor`.
 
-The agent loop in the editor matches 0.7.8: **get_context → expand_fold** (or **expand_gap** for `packet_gaps`). Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**; use **get_node_weights** to verify learning deltas.
+The agent loop in the editor matches 0.7.9: **get_context → expand_fold** (or **expand_gap** for `packet_gaps`). Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**; use **get_node_weights** to verify learning deltas.
 
 ## Install
 

--- a/editors/vscode-neuromesh/package.json
+++ b/editors/vscode-neuromesh/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-neuromesh",
   "displayName": "NeuroMesh",
   "description": "Evidence packets, reversible folds, and a live mesh sidebar for Cursor & VS Code. Don’t dump files — fold them.",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "publisher": "neuromesh",
   "license": "MIT",
   "homepage": "https://github.com/pinoox/neuromesh",


### PR DESCRIPTION
durable learning, parser relink, and Vue trace on stale snapshots.

- **Learning persistence (real).** `record_feedback` saves `graph.bin` via `workspace_root` (not MCP `cwd`). Episode IDs are checkpointed in the snapshot (`applied_learning_episodes`). Replay on startup applies only episodes missing from the checkpoint, then persists. MCP flushes graph state on graceful stdio shutdown.
- **Parser epoch relink.** `GRAPH_PARSER_EPOCH` (3) in snapshots; loading an older epoch clears `file_hashes` so the next index re-parses all files (Vue CALL edges on upgraded installs without manual `--force`).
- **Windows routing fix.** `tighten_focused_view_selection` normalizes `\` paths so `cart.js` is kept on checkout stepper tasks (gold `checkout_qty_stepper`).
- **Benchmark fixture.** `ProductGrid.vue` `@view` binding corrected to `ui.openProduct` (action lives in `ui.js`).