### PR TITLE
Close positive learning to emission loop in v0.7.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-api"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "chrono",
  "futures-util",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cache"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-cli"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "chrono",
  "dirs",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-context"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "chrono",
  "neuromesh-core",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-core"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "chrono",
  "dirs",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-graph"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "bincode",
  "chrono",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-index"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "blake3",
  "chrono",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-local-ai"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "neuromesh-core",
  "parking_lot",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-mcp"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "chrono",
  "neuromesh-cache",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-memory"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "chrono",
  "dirs",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-observability"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "chrono",
  "dirs",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-parser"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "neuromesh-core",
  "neuromesh-index",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-provider"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "futures-util",
  "neuromesh-core",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-router"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "neuromesh-context",
  "neuromesh-core",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "neuromesh-task"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "neuromesh-core",
  "neuromesh-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 exclude = ["tests/fixtures/mini-axum"]
 
 [workspace.package]
-version = "0.7.15"
+version = "0.7.16"
 edition = "2021"
 rust-version = "1.80"
 authors = ["NeuroMesh Team <team@neuromesh.local>"]

--- a/README.md
+++ b/README.md
@@ -325,6 +325,6 @@ Index snapshot from that eval run: **340 files · 3,132 nodes · 6,591 edges · 
 | [MCP](docs/mcp.md) · [CLI](docs/cli.md) | Tools and commands |
 | [Quality](docs/quality.md) | Gold, eval, numbers |
 | [Contributing](docs/contributing.md) | Come build a solver or a language |
-| [Changelog](docs/CHANGELOG.md) | 0.7.15 |
+| [Changelog](docs/CHANGELOG.md) | 0.7.16 |
 
 MIT · [LICENSE](LICENSE)

--- a/crates/neuromesh-context/src/activator.rs
+++ b/crates/neuromesh-context/src/activator.rs
@@ -465,6 +465,16 @@ impl ContextActivator {
             &focus_terms,
             &thresholds,
         );
+        EmissionPipeline::ensure_learned_emission(
+            graph,
+            &mut selection.optional,
+            &mut selection.scores,
+            &required_set,
+            &learning_index,
+            &focus_terms,
+            &thresholds,
+            selection.optional_cap,
+        );
 
         *self.last_physarum.lock() = PhysarumTelemetry {
             used: physarum_used,
@@ -3277,6 +3287,59 @@ import { useCartStore } from '../stores/cart.js'
         assert!(
             files.iter().any(|p| p.contains("routes.py")),
             "heavily reinforced routes.py must be emitted; files={files:?}"
+        );
+        let routes = view
+            .rank_candidates
+            .iter()
+            .find(|c| c.path.contains("routes.py"))
+            .expect("routes candidate");
+        assert!(routes.emitted, "routes.py must show emitted=true");
+    }
+
+    #[test]
+    fn positive_learning_unrelated_high_bonus_enters_emission() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("kosha-gap"));
+        graph.ingest_file(
+            &indexed("api/school.ts"),
+            &CodeIntelligenceEngine::analyze(
+                &PathBuf::from("school.ts"),
+                "export const scores = 1",
+                SourceLanguage::TypeScript,
+            ),
+            Some("export const scores = 1"),
+        );
+        graph.ingest_file(
+            &indexed("school/routes.py"),
+            &CodeIntelligenceEngine::analyze(
+                &PathBuf::from("routes.py"),
+                "def list_routes():\n    return []\n",
+                SourceLanguage::Python,
+            ),
+            Some("def list_routes():\n    return []\n"),
+        );
+        graph.ingest_file(
+            &indexed("school/scores_repo.py"),
+            &CodeIntelligenceEngine::analyze(
+                &PathBuf::from("scores_repo.py"),
+                "def load_scores():\n    return []\n",
+                SourceLanguage::Python,
+            ),
+            Some("def load_scores():\n    return []\n"),
+        );
+        graph.finalize_links();
+        let registry = Arc::new(ReversibleContextRegistry::new());
+        let activator = ContextActivator::new(registry);
+        let sig = TaskSignatureExtractor::extract("where are school scores handled");
+        for _ in 0..80 {
+            if let Some(node) = graph.resolve_feedback_node("school/routes.py") {
+                graph.reinforce_node_access(&node.id, true);
+            }
+        }
+        let view = activator.activate(&graph, &sig, OptimizationMode::Balanced);
+        let files = packet_paths(&view);
+        assert!(
+            files.iter().any(|p| p.contains("routes.py")),
+            "heavily learned routes.py must enter packet alongside seeds; files={files:?}"
         );
     }
 

--- a/crates/neuromesh-context/src/emission.rs
+++ b/crates/neuromesh-context/src/emission.rs
@@ -1,5 +1,7 @@
 use crate::selector::RankCandidate;
-use crate::unified_score::{cmp_score_path, compute_unified_file_score, file_path_str};
+use crate::unified_score::{
+    cmp_score_path, compute_unified_file_score, file_matches_focus_terms, file_path_str,
+};
 use neuromesh_core::{ContextScoreBreakdown, EmissionDropStage, NodeId, NodeType, Thresholds};
 use neuromesh_graph::NeuralProjectGraph;
 use std::collections::{HashMap, HashSet};
@@ -165,5 +167,143 @@ impl EmissionPipeline {
         out.sort_by(|a, b| cmp_score_path(a.score, &a.path, b.score, &b.path));
         out.truncate(24);
         out
+    }
+
+    /// Inject heavily reinforced files into the optional emission queue (positive learning loop).
+    #[allow(clippy::too_many_arguments)]
+    pub fn ensure_learned_emission(
+        graph: &NeuralProjectGraph,
+        optional: &mut Vec<NodeId>,
+        scores: &mut HashMap<NodeId, f32>,
+        required: &HashSet<NodeId>,
+        learning_index: &HashMap<NodeId, f32>,
+        focus_terms: &HashSet<String>,
+        thresholds: &Thresholds,
+        optional_cap: usize,
+    ) {
+        let min_bonus = thresholds.learning_promotion_min_bonus;
+        const UNRELATED_FORCE: f32 = 28.0;
+
+        let mut promoted: Vec<(NodeId, f32)> = graph
+            .high_learning_files(min_bonus, 24)
+            .into_iter()
+            .filter(|(id, bonus)| {
+                !required.contains(id)
+                    && !graph
+                        .file_min_base_relevance(id)
+                        .is_some_and(|r| r < thresholds.penalized_suppression_threshold)
+                    && (file_matches_focus_terms(graph, id, focus_terms)
+                        || *bonus >= UNRELATED_FORCE)
+            })
+            .map(|(id, _)| {
+                let utility = scores.get(&id).copied().unwrap_or(12.0);
+                let breakdown = compute_unified_file_score(
+                    graph,
+                    &id,
+                    utility,
+                    learning_index,
+                    focus_terms,
+                    thresholds,
+                    0.0,
+                );
+                (id, breakdown.final_score)
+            })
+            .collect();
+        promoted.sort_by(|a, b| {
+            cmp_score_path(
+                a.1,
+                &file_path_str(graph, &a.0),
+                b.1,
+                &file_path_str(graph, &b.0),
+            )
+        });
+
+        for (id, score) in promoted {
+            scores.insert(id.clone(), score);
+            if let Some(pos) = optional.iter().position(|x| x == &id) {
+                optional.remove(pos);
+            } else if optional.len() >= optional_cap {
+                let weakest = optional
+                    .iter()
+                    .enumerate()
+                    .min_by(|(_, a), (_, b)| {
+                        let sa = scores.get(*a).copied().unwrap_or(0.0);
+                        let sb = scores.get(*b).copied().unwrap_or(0.0);
+                        cmp_score_path(sa, &file_path_str(graph, a), sb, &file_path_str(graph, b))
+                    })
+                    .map(|(idx, _)| idx);
+                if let Some(idx) = weakest {
+                    let weak_score = scores.get(&optional[idx]).copied().unwrap_or(0.0);
+                    if score <= weak_score + 1.0 {
+                        continue;
+                    }
+                    optional.remove(idx);
+                }
+            }
+            optional.insert(0, id);
+        }
+        optional.truncate(optional_cap);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use neuromesh_core::ProjectId;
+    use neuromesh_graph::NeuralProjectGraph;
+
+    #[test]
+    fn ensure_learned_emission_prepends_focused_file() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("promo"));
+        let promo_path = std::path::PathBuf::from("src/components/PromoCodeInput.vue");
+        let file = neuromesh_index::IndexedFile::new(
+            ProjectId::new("promo"),
+            promo_path.clone(),
+            promo_path.clone(),
+            "export default { name: 'PromoCodeInput' }",
+            "hash".to_string(),
+            40,
+            chrono::Utc::now(),
+        );
+        graph.ingest_file(
+            &file,
+            &neuromesh_parser::CodeIntelligenceEngine::analyze(
+                &promo_path,
+                "export default { name: 'PromoCodeInput' }",
+                neuromesh_index::SourceLanguage::Vue,
+            ),
+            Some("export default { name: 'PromoCodeInput' }"),
+        );
+        if let Some(node) = graph.resolve_feedback_node("PromoCodeInput") {
+            for _ in 0..8 {
+                graph.reinforce_node_access(&node.id, true);
+            }
+        }
+        let thresholds = Thresholds::default();
+        let learning_index = graph.file_learning_boost_index();
+        let focus: HashSet<String> = ["promocodeinput".into(), "checkout".into()]
+            .into_iter()
+            .collect();
+        let mut optional = Vec::new();
+        let mut scores = HashMap::new();
+        let required = HashSet::new();
+        EmissionPipeline::ensure_learned_emission(
+            &graph,
+            &mut optional,
+            &mut scores,
+            &required,
+            &learning_index,
+            &focus,
+            &thresholds,
+            5,
+        );
+        assert!(
+            optional.iter().any(|id| {
+                graph
+                    .get_node(id)
+                    .is_some_and(|n| n.file_path.to_string_lossy().contains("PromoCodeInput"))
+            }),
+            "reinforced PromoCodeInput must enter optional emission queue"
+        );
     }
 }

--- a/crates/neuromesh-context/src/selector.rs
+++ b/crates/neuromesh-context/src/selector.rs
@@ -559,6 +559,7 @@ pub fn select(
         &required,
         optional_files,
         max_extra_files,
+        thresholds.learning_promotion_min_bonus,
     );
 
     let mut optional_ids = Vec::new();
@@ -771,12 +772,10 @@ fn promote_high_learning_into_emitted(
     required: &HashSet<NodeId>,
     mut optional: Vec<(NodeId, f32)>,
     cap: usize,
+    learned_swap_min: f32,
 ) -> Vec<(NodeId, f32)> {
-    const LEARNED_SWAP_MIN: f32 = 18.0;
-    const DISPLACE_MAX: f32 = 20.0;
-
     let mut promoted: Vec<(NodeId, f32)> = graph
-        .high_learning_files(LEARNED_SWAP_MIN, 16)
+        .high_learning_files(learned_swap_min, 16)
         .into_iter()
         .filter(|(id, _)| !required.contains(id) && !optional.iter().any(|(oid, _)| oid == id))
         .map(|(id, bonus)| {
@@ -794,11 +793,10 @@ fn promote_high_learning_into_emitted(
         if let Some((min_idx, min_score)) = optional
             .iter()
             .enumerate()
-            .filter(|(_, (_, s))| *s <= DISPLACE_MAX)
             .min_by(|(_, a), (_, b)| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
             .map(|(idx, (_, s))| (idx, *s))
         {
-            if learned_score > min_score + 2.0 {
+            if learned_score > min_score + 1.0 {
                 optional[min_idx] = (learned_id, learned_score);
             }
         }

--- a/crates/neuromesh-core/src/config.rs
+++ b/crates/neuromesh-core/src/config.rs
@@ -99,6 +99,9 @@ pub struct Thresholds {
     /// Hard cap on learned score component in unified ranking.
     #[serde(default = "default_max_learned_influence")]
     pub max_learned_influence: f32,
+    /// Min learning bonus before a reinforced file can be injected into emission.
+    #[serde(default = "default_learning_promotion_min_bonus")]
+    pub learning_promotion_min_bonus: f32,
 }
 
 fn default_penalized_suppression() -> f32 {
@@ -112,6 +115,9 @@ fn default_learning_decay_half_life() -> f32 {
 }
 fn default_max_learned_influence() -> f32 {
     48.0
+}
+fn default_learning_promotion_min_bonus() -> f32 {
+    14.0
 }
 
 impl Default for Thresholds {
@@ -127,6 +133,7 @@ impl Default for Thresholds {
             learning_relevance_cap_unrelated: default_learning_unrelated_cap(),
             learning_decay_half_life_days: default_learning_decay_half_life(),
             max_learned_influence: default_max_learned_influence(),
+            learning_promotion_min_bonus: default_learning_promotion_min_bonus(),
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes live here. The README stays a product guide, not
 
 ## Unreleased
 
+## 0.7.16 — 2026-08-28
+
+Close the positive learning→emission loop (audit v0.7.15 follow-up).
+
+- **Positive promotion.** `EmissionPipeline::ensure_learned_emission` prepends heavily reinforced files into the optional emission queue before materialize (focus match or `learning_bonus ≥ 28`).
+- **Selector swap.** `promote_high_learning_into_emitted` uses `learning_promotion_min_bonus` (default **14**, was hard-coded **18**) so +8 reinforcement (~17 bonus) can enter the packet; displacement no longer caps victims at utility ≤ 20.
+- **Threshold.** `Thresholds.learning_promotion_min_bonus` in config (serde default 14).
+- **CI.** `positive_learning_unrelated_high_bonus_enters_emission`, `ensure_learned_emission_prepends_focused_file`; kosha `routes.py` must show `emitted: true`.
+
 ## 0.7.15 — 2026-08-28
 
 Adaptive context routing: learning now drives emission with full observability and benchmark harness.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ Seed files always ship (skeletonized)
   ▼
 Fill callees, usages, imports under fill_cap
   │
-  ├─ learning rerank + emission pipeline (v0.7.15+)
+  ├─ learning rerank + bidirectional emission (v0.7.16+)
   │
   ├─ max_savings: seeds only
   ├─ balanced: +5k extra, soft crate cap

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -133,4 +133,4 @@ Pass that `fold_id` to `neuromesh_expand_fold` as `fold_id`, `node_id`, or `quer
 
 Effects apply on the **next** `get_context` in the same MCP process: search ranking, selector fill, unified scoring, and the **emission pipeline** (which files actually ship after fill/packet caps). Negative feedback lowers `base_relevance` and can suppress penalized files from the optional set. Use `neuromesh_get_node_weights` before and after feedback to verify deltas. When a file shows `selected: true` but is missing from `files[]`, call `neuromesh_explain_packet` and check `emitted` / `drop_stage` on `selection.candidates`.
 
-Learning does not change a packet mid-request; restart the MCP server to load persisted graph state from a prior session. Benchmark the learning loop locally with `neuromesh eval --learning`.
+Learning does not change a packet mid-request; restart the MCP server to load persisted graph state from a prior session. Positive reinforcement (`learning_bonus ≥ 14`, or `≥ 28` without focus match) can **add** files to the next packet; negative reinforcement drops penalized hop-expanded files. Benchmark locally with `neuromesh eval --learning`.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -41,14 +41,15 @@ Debug `neuromesh eval` on the same repo: activation ~157 ms / ~104 ms; full inde
 
 That is “did the packet already hold the files a developer would open”, not a live multi-agent trial. Quote this table; do not invent a global 99% figure.
 
-## Learning → emission (v0.7.15)
+## Learning → emission (v0.7.16)
 
-Feedback changes **which files are emitted**, not only candidate scores. The activator runs an `EmissionPipeline` that records `emitted` and `drop_stage` (`penalized_suppress`, `fill_cap`, `packet_cap`, …) through selector → post-filters → materialize.
+Feedback changes **which files are emitted** in both directions: penalized hop-expanded files drop out; heavily reinforced files (focus match or `learning_bonus ≥ 28`) are prepended into optional emission via `ensure_learned_emission`. Default promotion floor: `learning_promotion_min_bonus` **14** (covers +8 strong reinforcement ≈ 17 bonus).
 
 Causal routing is gated in CI:
 
 ```bash
 cargo test -p neuromesh-context learning_to_emission
+cargo test -p neuromesh-context positive_learning
 cargo test -p neuromesh-context deterministic_packet_same_state
 cargo test -p neuromesh-context catastrophic_learning
 ```
@@ -57,7 +58,7 @@ cargo test -p neuromesh-context catastrophic_learning
 
 `neuromesh_explain_packet` → `selection.candidates` includes `selected`, `emitted`, `drop_stage`, and `score_breakdown` (`utility_score`, `learned_score`, `negative_penalty`, `final_score`). Use these when `selected: true` but a file is missing from the packet.
 
-Configurable learning thresholds live in `Thresholds` (`penalized_suppression_threshold`, `learning_relevance_cap_unrelated`, `learning_decay_half_life_days`, `max_learned_influence`) — see `neuromesh-core` config defaults.
+Configurable learning thresholds live in `Thresholds` (`penalized_suppression_threshold`, `learning_promotion_min_bonus`, `learning_relevance_cap_unrelated`, `learning_decay_half_life_days`, `max_learned_influence`) — see `neuromesh-core` config defaults.
 
 ## Shop fixture (mini-shop)
 

--- a/editors/vscode-neuromesh/README.md
+++ b/editors/vscode-neuromesh/README.md
@@ -2,7 +2,7 @@
 
 Sidebar mesh stats, a packet inspector, fold CodeLens, and the galaxy UI — talking to a running `neuromesh monitor`.
 
-The agent loop in the editor matches 0.7.15: **get_context → expand_fold** (or **expand_gap** for `packet_gaps`). Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**; use **get_node_weights** to verify learning deltas.
+The agent loop in the editor matches 0.7.16: **get_context → expand_fold** (or **expand_gap** for `packet_gaps`). Grep (`search_symbols`) when coverage is `partial` or `no_seed_resolved`. After a good edit, **record_feedback**; use **get_node_weights** to verify learning deltas.
 
 ## Install
 

--- a/editors/vscode-neuromesh/package.json
+++ b/editors/vscode-neuromesh/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-neuromesh",
   "displayName": "NeuroMesh",
   "description": "Evidence packets, reversible folds, and a live mesh sidebar for Cursor & VS Code. Don’t dump files — fold them.",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "publisher": "neuromesh",
   "license": "MIT",
   "homepage": "https://github.com/pinoox/neuromesh",


### PR DESCRIPTION
Close the positive learning→emission loop (audit v0.7.15 follow-up).

- **Positive promotion.** `EmissionPipeline::ensure_learned_emission` prepends heavily reinforced files into the optional emission queue before materialize (focus match or `learning_bonus ≥ 28`).
- **Selector swap.** `promote_high_learning_into_emitted` uses `learning_promotion_min_bonus` (default **14**, was hard-coded **18**) so +8 reinforcement (~17 bonus) can enter the packet; displacement no longer caps victims at utility ≤ 20.
- **Threshold.** `Thresholds.learning_promotion_min_bonus` in config (serde default 14).
- **CI.** `positive_learning_unrelated_high_bonus_enters_emission`, `ensure_learned_emission_prepends_focused_file`; `routes.py` must show `emitted: true`.
