### PR TITLE
fix: enforce project isolation — stable ProjectId, clean workspace hot-swap, CI leakage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run Automated Unit & Integration Tests
         run: cargo test --all --verbose
 
+      - name: Cross-project isolation gate
+        run: cargo test -p neuromesh-context --test cross_project_isolation -- --nocapture
+
       - name: Embedding feature tests
         run: cargo test -p neuromesh-context --features embeddings --verbose
 

--- a/crates/neuromesh-api/src/server.rs
+++ b/crates/neuromesh-api/src/server.rs
@@ -475,7 +475,7 @@ impl HttpServer {
                                 .map(|n| n.to_string_lossy().into_owned())
                                 .unwrap_or_else(|| "project".to_string());
 
-                            let new_project_id = ProjectId::new(&project_name);
+                            let new_project_id = neuromesh_core::stable_project_id(&target_path);
                             state.graph.clear(Some(new_project_id.clone()));
                             state.graph.set_workspace(&target_path);
                             let walker =
@@ -574,11 +574,11 @@ impl HttpServer {
                         let fallback_dir =
                             std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
                         *state.workspace_path.write() = fallback_dir.clone();
-                        let fallback_name = fallback_dir
+                        let _fallback_name = fallback_dir
                             .file_name()
                             .map(|n| n.to_string_lossy().into_owned())
                             .unwrap_or_else(|| "project".to_string());
-                        let new_pid = ProjectId::new(&fallback_name);
+                        let new_pid = neuromesh_core::stable_project_id(&fallback_dir);
                         state.graph.clear(Some(new_pid.clone()));
                         let walker = Self::project_walker(&state, fallback_dir, new_pid);
                         if let Ok(scanned) = walker.scan() {

--- a/crates/neuromesh-cli/src/commands/embed.rs
+++ b/crates/neuromesh-cli/src/commands/embed.rs
@@ -80,11 +80,7 @@ fn rebuild(args: &[String]) -> Result<()> {
                     .into(),
             ));
         }
-        let project_name = current_dir
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("project");
-        let project_id = neuromesh_core::ProjectId::new(project_name);
+        let project_id = neuromesh_core::stable_project_id(&current_dir);
         let graph = Arc::new(NeuralProjectGraph::new(project_id.clone()));
         let _ = graph.load_persisted(&current_dir);
         if graph.stats().total_nodes == 0 {

--- a/crates/neuromesh-cli/src/commands/graph.rs
+++ b/crates/neuromesh-cli/src/commands/graph.rs
@@ -1,4 +1,4 @@
-use neuromesh_core::{ProjectId, Result};
+use neuromesh_core::Result;
 use neuromesh_graph::NeuralProjectGraph;
 
 use super::{configured_walker, FileCapArg};
@@ -11,7 +11,7 @@ pub fn execute() -> Result<()> {
         .unwrap_or("project")
         .to_string();
 
-    let project_id = ProjectId::new(&project_name);
+    let project_id = neuromesh_core::stable_project_id(&current_dir);
     let walker = configured_walker(
         current_dir.clone(),
         project_id.clone(),

--- a/crates/neuromesh-cli/src/commands/index.rs
+++ b/crates/neuromesh-cli/src/commands/index.rs
@@ -1,4 +1,4 @@
-use neuromesh_core::{Config, ProjectId, Result, RetrievalEngine};
+use neuromesh_core::{Config, Result, RetrievalEngine};
 use neuromesh_graph::NeuralProjectGraph;
 use neuromesh_memory::{MemoryDatabase, ProjectFact};
 use std::fs;
@@ -15,12 +15,6 @@ pub fn execute(
     }
     let cfg = Config::load();
     let current_dir = neuromesh_index::assert_safe_workspace(&std::env::current_dir()?)?;
-    let project_name = current_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("neuromesh-project")
-        .to_string();
-
     if let Some(path) = persist_file_cap(cap)? {
         let label = match cap {
             FileCapArg::Auto => "auto".to_string(),
@@ -30,7 +24,7 @@ pub fn execute(
         println!("Saved          : {} (max_files = {label})", path.display());
     }
 
-    let project_id = ProjectId::new(&project_name);
+    let project_id = neuromesh_core::stable_project_id(&current_dir);
     let walker = configured_walker(current_dir.clone(), project_id.clone(), cap);
 
     println!(

--- a/crates/neuromesh-cli/src/commands/memory.rs
+++ b/crates/neuromesh-cli/src/commands/memory.rs
@@ -1,15 +1,9 @@
-use neuromesh_core::{ProjectId, Result};
+use neuromesh_core::Result;
 use neuromesh_memory::MemoryDatabase;
 
 pub fn execute() -> Result<()> {
     let current_dir = std::env::current_dir()?;
-    let project_name = current_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("project")
-        .to_string();
-
-    let project_id = ProjectId::new(&project_name);
+    let project_id = neuromesh_core::stable_project_id(&current_dir);
     let db_path = neuromesh_core::memory_db_path(&current_dir);
 
     println!("\n🧠 NeuroMesh Persistent Memory");

--- a/crates/neuromesh-cli/src/commands/mod.rs
+++ b/crates/neuromesh-cli/src/commands/mod.rs
@@ -132,8 +132,22 @@ pub fn spawn_live_sync(
     dir: std::path::PathBuf,
     pid: ProjectId,
     cap: FileCapArg,
+    explicit: bool,
 ) {
-    if !ProjectWalker::is_safe_workspace(&dir) {
+    // The one choke point where the CLI starts a scan. A path the user gave us
+    // only has to be safe; a path we guessed also has to look like a project,
+    // which is what stops a server launched with no workspace from indexing
+    // whatever happens to sit in the current directory.
+    let rejection = if explicit {
+        ProjectWalker::workspace_rejection_reason(&dir)
+    } else {
+        ProjectWalker::discovered_workspace_rejection_reason(&dir)
+    };
+    if let Some(reason) = rejection {
+        eprintln!("NeuroMesh will not index this workspace: {reason}");
+        eprintln!(
+            "NeuroMesh: pass a project path (`neuromesh mcp <path>`) or set NEUROMESH_WORKSPACE"
+        );
         graph.mark_index_ready();
         return;
     }

--- a/crates/neuromesh-cli/src/commands/monitor.rs
+++ b/crates/neuromesh-cli/src/commands/monitor.rs
@@ -46,7 +46,9 @@ pub async fn execute(port_override: Option<u16>, cap: FileCapArg) -> Result<()> 
     let bg_graph = graph.clone();
     let bg_dir = current_dir.clone();
     let bg_pid = project_id.clone();
-    super::spawn_live_sync(bg_graph, bg_dir, bg_pid, cap);
+    // `monitor` has no workspace argument; the root is the current directory,
+    // so it is a guess and has to look like a project.
+    super::spawn_live_sync(bg_graph, bg_dir, bg_pid, cap, false);
 
     let state = AppState::new(config, graph, memory_db, provider);
     state.attach_graph_proxy_if_configured().await;

--- a/crates/neuromesh-cli/src/commands/monitor.rs
+++ b/crates/neuromesh-cli/src/commands/monitor.rs
@@ -1,5 +1,5 @@
 use neuromesh_api::{AppState, HttpServer};
-use neuromesh_core::{Config, ProjectId, Result};
+use neuromesh_core::{Config, Result};
 use neuromesh_graph::NeuralProjectGraph;
 use neuromesh_memory::MemoryDatabase;
 use neuromesh_provider::ProviderFactory;
@@ -19,13 +19,7 @@ pub async fn execute(port_override: Option<u16>, cap: FileCapArg) -> Result<()> 
     }
     config = apply_file_cap(config, cap);
 
-    let project_name = current_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("project")
-        .to_string();
-
-    let project_id = ProjectId::new(&project_name);
+    let project_id = neuromesh_core::stable_project_id(&current_dir);
     let graph = Arc::new(NeuralProjectGraph::new(project_id.clone()));
     if graph.load_persisted(&current_dir) {
         let stats = graph.stats();

--- a/crates/neuromesh-cli/src/commands/optimize.rs
+++ b/crates/neuromesh-cli/src/commands/optimize.rs
@@ -1,6 +1,6 @@
 use neuromesh_context::gold::packet_file_names;
 use neuromesh_context::{ContextActivator, ReversibleContextRegistry};
-use neuromesh_core::{OptimizationMode, ProjectId, Result};
+use neuromesh_core::{OptimizationMode, Result};
 use neuromesh_graph::NeuralProjectGraph;
 use neuromesh_task::TaskSignatureExtractor;
 use std::sync::Arc;
@@ -13,12 +13,7 @@ pub fn execute(task_prompt: Option<String>) -> Result<()> {
         task_prompt.unwrap_or_else(|| "How does handle_tool_call extract intent?".to_string());
 
     let current_dir = neuromesh_index::assert_safe_workspace(&std::env::current_dir()?)?;
-    let project_name = current_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("project")
-        .to_string();
-    let project_id = ProjectId::new(&project_name);
+    let project_id = neuromesh_core::stable_project_id(&current_dir);
     let walker = configured_walker(
         current_dir.clone(),
         project_id.clone(),

--- a/crates/neuromesh-cli/src/commands/packet.rs
+++ b/crates/neuromesh-cli/src/commands/packet.rs
@@ -2,7 +2,7 @@ use neuromesh_context::gold::{packet_file_names, packet_paths};
 use neuromesh_context::retrieval::apply_auto_extract_keywords;
 use neuromesh_context::{ContextActivator, ReversibleContextRegistry};
 use neuromesh_core::{
-    Config, OptimizationMode, ProjectId, Result, RetrievalEngine, RetrievalMetadata, TaskSignature,
+    Config, OptimizationMode, Result, RetrievalEngine, RetrievalMetadata, TaskSignature,
 };
 use neuromesh_graph::NeuralProjectGraph;
 use neuromesh_task::TaskSignatureExtractor;
@@ -64,12 +64,7 @@ pub fn execute(args: &[String]) -> Result<()> {
     })?;
 
     let current_dir = neuromesh_index::assert_safe_workspace(&std::env::current_dir()?)?;
-    let project_name = current_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("project")
-        .to_string();
-    let project_id = ProjectId::new(&project_name);
+    let project_id = neuromesh_core::stable_project_id(&current_dir);
     let walker = configured_walker(
         current_dir.clone(),
         project_id.clone(),

--- a/crates/neuromesh-cli/src/commands/smoke.rs
+++ b/crates/neuromesh-cli/src/commands/smoke.rs
@@ -1,5 +1,5 @@
 use neuromesh_context::{ContextActivator, ReversibleContextRegistry};
-use neuromesh_core::{OptimizationMode, ProjectId, Result};
+use neuromesh_core::{OptimizationMode, Result};
 use neuromesh_graph::NeuralProjectGraph;
 use neuromesh_observability::{load_persisted_history, summarize_history, TelemetrySurface};
 use neuromesh_task::TaskSignatureExtractor;
@@ -10,12 +10,7 @@ use super::{configured_walker, snapshot, FileCapArg};
 
 pub fn execute() -> Result<()> {
     let current_dir = neuromesh_index::assert_safe_workspace(&std::env::current_dir()?)?;
-    let project_name = current_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("project")
-        .to_string();
-    let project_id = ProjectId::new(&project_name);
+    let project_id = neuromesh_core::stable_project_id(&current_dir);
     let walker = configured_walker(
         current_dir.clone(),
         project_id.clone(),

--- a/crates/neuromesh-cli/src/commands/snapshot.rs
+++ b/crates/neuromesh-cli/src/commands/snapshot.rs
@@ -79,12 +79,7 @@ pub fn collect_from_cwd(
 ) -> Result<ProjectSnapshot, neuromesh_core::NeuroMeshError> {
     let cwd = std::env::current_dir()?;
     let root = ProjectWalker::discover_workspace(&cwd);
-    let project_name = root
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("project")
-        .to_string();
-    let project_id = ProjectId::new(&project_name);
+    let project_id = neuromesh_core::stable_project_id(&root);
     let graph = NeuralProjectGraph::new(project_id.clone());
     let _ = graph.load_persisted(&root);
     Ok(collect(&root, &project_id, &graph, all_projects))

--- a/crates/neuromesh-cli/src/commands/status.rs
+++ b/crates/neuromesh-cli/src/commands/status.rs
@@ -1,16 +1,11 @@
-use neuromesh_core::{ProjectId, Result};
+use neuromesh_core::Result;
 use neuromesh_graph::NeuralProjectGraph;
 
 use super::{configured_walker, snapshot, FileCapArg};
 
 pub fn execute() -> Result<()> {
     let current_dir = std::env::current_dir()?;
-    let project_name = current_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("project")
-        .to_string();
-    let project_id = ProjectId::new(&project_name);
+    let project_id = neuromesh_core::stable_project_id(&current_dir);
     let walker = configured_walker(
         current_dir.clone(),
         project_id.clone(),

--- a/crates/neuromesh-cli/src/commands/usage.rs
+++ b/crates/neuromesh-cli/src/commands/usage.rs
@@ -1,4 +1,4 @@
-use neuromesh_core::{Config, ProjectId, Result};
+use neuromesh_core::{Config, Result};
 use neuromesh_observability::{filter_history, load_persisted_history, summarize_history};
 use std::net::{SocketAddr, TcpStream};
 use std::time::Duration;
@@ -72,7 +72,7 @@ pub fn execute(args: &[String]) -> Result<()> {
         .and_then(|n| n.to_str())
         .unwrap_or("project")
         .to_string();
-    let project_id = ProjectId::new(&project_name);
+    let project_id = neuromesh_core::stable_project_id(&current_dir);
     let workspace = current_dir.display().to_string();
 
     let file_path = neuromesh_observability::telemetry_file_path();

--- a/crates/neuromesh-cli/src/main.rs
+++ b/crates/neuromesh-cli/src/main.rs
@@ -1,6 +1,6 @@
 mod commands;
 
-use neuromesh_core::{Config, ProjectId, Result};
+use neuromesh_core::{Config, Result};
 use neuromesh_graph::NeuralProjectGraph;
 use neuromesh_graph_proxy::{resolve_mcp_launch_spec, GraphProxySession};
 use neuromesh_memory::MemoryDatabase;
@@ -155,13 +155,9 @@ async fn async_main(command: &str, args: &[String]) -> Result<()> {
                 neuromesh_index::resolve_mcp_startup_workspace()
             };
             eprintln!("NeuroMesh MCP workspace: {}", current_dir.display());
-            let project_name = current_dir
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("project")
-                .to_string();
-
-            let project_id = ProjectId::new(&project_name);
+            // Derived from the canonical project path, not the directory name:
+            // unrelated checkouts both called `app` used to share one identity.
+            let project_id = neuromesh_core::stable_project_id(&current_dir);
             let graph = Arc::new(NeuralProjectGraph::new(project_id.clone()));
             graph.set_workspace(&current_dir);
 

--- a/crates/neuromesh-cli/src/main.rs
+++ b/crates/neuromesh-cli/src/main.rs
@@ -167,12 +167,17 @@ async fn async_main(command: &str, args: &[String]) -> Result<()> {
                     .or_else(|_| MemoryDatabase::open_in_memory())
                     .unwrap_or_else(|_| MemoryDatabase::open_in_memory().unwrap()),
             );
-            if neuromesh_index::ProjectWalker::is_safe_workspace(&current_dir) {
-                for fact in neuromesh_memory::extract_project_facts(&current_dir, &project_id) {
-                    let _ = memory_db.save_project_fact(&fact);
+            match neuromesh_index::ProjectWalker::workspace_rejection_reason(&current_dir) {
+                None => {
+                    for fact in neuromesh_memory::extract_project_facts(&current_dir, &project_id) {
+                        let _ = memory_db.save_project_fact(&fact);
+                    }
                 }
-            } else {
-                graph.mark_index_ready();
+                Some(_) => {
+                    // Serve, but seed nothing. `spawn_live_sync` reports why and
+                    // skips the scan.
+                    graph.mark_index_ready();
+                }
             }
 
             let registry = Arc::new(neuromesh_context::ReversibleContextRegistry::new());
@@ -258,7 +263,13 @@ async fn async_main(command: &str, args: &[String]) -> Result<()> {
             {
                 graph.mark_index_loading();
             }
-            commands::spawn_live_sync(graph.clone(), current_dir.clone(), project_id.clone(), cap);
+            commands::spawn_live_sync(
+                graph.clone(),
+                current_dir.clone(),
+                project_id.clone(),
+                cap,
+                explicit,
+            );
 
             let server = neuromesh_mcp::McpServer::new(handler);
             server.run_stdio().await?;

--- a/crates/neuromesh-context/tests/cross_project_isolation.rs
+++ b/crates/neuromesh-context/tests/cross_project_isolation.rs
@@ -1,0 +1,180 @@
+//! P0 definition of done.
+//!
+//! One runtime serves project A, then project B. Nothing from A may appear in
+//! B's packet. The two fixtures deliberately share `scripts/util.py`
+//! byte-for-byte, because that is the case the baseline got wrong:
+//! `ingest_file_keep` returns early when a path's stored hash equals the
+//! incoming hash, so without a clean swap A's nodes for that path survive into
+//! B's graph, still carrying A's project id.
+//!
+//! Runs as a single test on purpose — the scenarios share fixture slots under
+//! one `NEUROMESH_HOME`, and splitting them would race on `save_persisted`.
+
+use neuromesh_context::retrieval::apply_auto_extract_keywords;
+use neuromesh_context::{ContextActivator, ReversibleContextRegistry};
+use neuromesh_core::{stable_project_id, NodeType, OptimizationMode};
+use neuromesh_graph::NeuralProjectGraph;
+use neuromesh_task::TaskSignatureExtractor;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Keep `save_persisted` out of the developer's real `~/.neuromesh`.
+fn use_temp_neuromesh_home() {
+    let home = std::env::temp_dir().join(format!("nm-iso-home-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&home);
+    std::env::set_var("NEUROMESH_HOME", &home);
+}
+
+/// Copy a fixture out of this repository into its own directory.
+///
+/// `stable_project_id` resolves to the nearest enclosing git repository, which
+/// is the behaviour we want — one repo is one project, and splitting a monorepo
+/// into sub-projects is a separate, explicit feature. It also means every
+/// fixture *inside* this repo shares this repo's id. Staging each fixture in
+/// its own directory outside any repository is what two real checkouts look
+/// like, and it keeps the test from writing anywhere in the source tree.
+fn staged_fixture(name: &str) -> PathBuf {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("tests")
+        .join("fixtures")
+        .join(name);
+    assert!(src.is_dir(), "fixture {name} must exist at {src:?}");
+
+    let dst = std::env::temp_dir().join(format!("nm-iso-{}-{}", name, std::process::id()));
+    let _ = std::fs::remove_dir_all(&dst);
+    copy_tree(&src, &dst);
+    dst.canonicalize().expect("staged fixture path")
+}
+
+fn copy_tree(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).expect("create staged dir");
+    for entry in std::fs::read_dir(src).expect("read fixture dir") {
+        let entry = entry.expect("fixture entry");
+        let to = dst.join(entry.file_name());
+        if entry.file_type().expect("entry type").is_dir() {
+            copy_tree(&entry.path(), &to);
+        } else {
+            std::fs::copy(entry.path(), &to).expect("copy fixture file");
+        }
+    }
+}
+
+/// Exactly what `adopt_workspace_from_initialize` does on a workspace change.
+fn swap_to(graph: &NeuralProjectGraph, root: &Path) {
+    let pid = stable_project_id(root);
+    graph.clear(Some(pid.clone()));
+    graph.set_workspace(root);
+    graph.reindex_incremental(root, pid, Some(500));
+}
+
+fn packet_files(graph: &NeuralProjectGraph, prompt: &str) -> Vec<String> {
+    let registry = Arc::new(ReversibleContextRegistry::new());
+    let activator = ContextActivator::new(registry);
+    let mut sig = TaskSignatureExtractor::extract(prompt);
+    apply_auto_extract_keywords(&mut sig, prompt, true);
+    let view = activator.activate(graph, &sig, OptimizationMode::Balanced);
+    view.active_nodes
+        .iter()
+        .map(|n| n.node.file_path.to_string_lossy().replace('\\', "/"))
+        .collect()
+}
+
+fn indexed_files(graph: &NeuralProjectGraph) -> Vec<String> {
+    let mut files: Vec<String> = graph
+        .get_nodes_map()
+        .into_values()
+        .filter(|node| node.node_type == NodeType::File)
+        .map(|node| node.file_path.to_string_lossy().replace('\\', "/"))
+        .collect();
+    files.sort();
+    files
+}
+
+fn file_node_project_id(graph: &NeuralProjectGraph, rel: &str) -> Option<String> {
+    graph
+        .get_nodes_map()
+        .into_values()
+        .find(|node| {
+            node.node_type == NodeType::File
+                && node.file_path.to_string_lossy().replace('\\', "/") == rel
+        })
+        .map(|node| node.project_id.to_string())
+}
+
+#[test]
+fn switching_projects_leaks_nothing_into_the_next_packet() {
+    use_temp_neuromesh_home();
+
+    let web = staged_fixture("iso-web-rust");
+    let ml = staged_fixture("iso-ml-python");
+    assert_ne!(
+        stable_project_id(&web),
+        stable_project_id(&ml),
+        "staged fixtures must be distinct projects ({web:?} vs {ml:?})"
+    );
+
+    let web_pid = stable_project_id(&web).to_string();
+    let ml_pid = stable_project_id(&ml).to_string();
+    let graph = NeuralProjectGraph::new(stable_project_id(&web));
+
+    // ---- project A: the Rust web service ----
+    swap_to(&graph, &web);
+    assert!(
+        file_node_project_id(&graph, "src/router.rs").is_some(),
+        "project A must actually index; indexed files: {:?}",
+        indexed_files(&graph)
+    );
+    assert_eq!(graph.assert_single_project(), Ok(()));
+
+    // ---- the switch, then project B: the PyTorch detection project ----
+    swap_to(&graph, &ml);
+
+    // The invariant is the strongest statement: no node anywhere in the graph
+    // belongs to another project.
+    assert_eq!(
+        graph.assert_single_project(),
+        Ok(()),
+        "project A nodes survived the swap"
+    );
+    let after_swap = indexed_files(&graph);
+    assert!(
+        after_swap.iter().all(|f| !f.ends_with(".rs")),
+        "project A files are still in the graph after the swap: {after_swap:?}"
+    );
+
+    let ml_files = packet_files(&graph, "why did the model mAP drop during evaluation");
+    let leaked: Vec<&String> = ml_files.iter().filter(|f| f.ends_with(".rs")).collect();
+    assert!(
+        leaked.is_empty(),
+        "cross-project leak into project B's packet: {leaked:?} (full packet {ml_files:?})"
+    );
+    assert!(
+        !ml_files.is_empty(),
+        "project B packet must not be empty, or the check above proves nothing"
+    );
+
+    // ---- the shared byte-identical file must now belong to project B ----
+    assert_eq!(
+        file_node_project_id(&graph, "scripts/util.py").as_deref(),
+        Some(ml_pid.as_str()),
+        "the file both projects share must be owned by the current project"
+    );
+
+    // ---- swapping back is symmetric ----
+    swap_to(&graph, &web);
+    assert_eq!(graph.assert_single_project(), Ok(()));
+    assert_eq!(
+        file_node_project_id(&graph, "scripts/util.py").as_deref(),
+        Some(web_pid.as_str()),
+        "swapping back must re-own the shared file"
+    );
+
+    // ---- re-indexing the same project is a no-op for the invariant ----
+    swap_to(&graph, &web);
+    assert_eq!(graph.assert_single_project(), Ok(()));
+
+    let _ = std::fs::remove_dir_all(&web);
+    let _ = std::fs::remove_dir_all(&ml);
+}

--- a/crates/neuromesh-core/src/lib.rs
+++ b/crates/neuromesh-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod embedding_config;
 pub mod error;
 pub mod graph_backend;
 pub mod paths;
+pub mod project_id;
 pub mod retrieval_engine;
 pub mod seed_config;
 pub mod source_path;
@@ -25,6 +26,7 @@ pub use paths::{
     project_config_path, project_data_dir, save_store_policy, trust_workspace_local,
     untrust_workspace_local, uses_local_dotdir, ProjectStore,
 };
+pub use project_id::{path_is_within, project_root, stable_project_id, stable_project_id_for_root};
 pub use retrieval_engine::{RetrievalConfig, RetrievalEngine};
 pub use seed_config::{
     NmConfigOverlay, PacketHeaderConfig, SeedEngineId, SeedResolutionConfig,

--- a/crates/neuromesh-core/src/project_id.rs
+++ b/crates/neuromesh-core/src/project_id.rs
@@ -1,0 +1,188 @@
+//! Stable, deterministic project identity.
+//!
+//! Before this module a [`ProjectId`] was built from the *directory name*
+//! (`ProjectId::new(path.file_name())`), so two unrelated checkouts both called
+//! `app`, `api`, or `backend` shared one identity. That made `ContextNode::project_id`
+//! useless as an isolation signal and made "is this the same project?" checks
+//! silently wrong.
+//!
+//! Here a `ProjectId` is a **pure function of the canonical path of the project
+//! root** — the nearest enclosing git repository, or the workspace itself when the
+//! directory is not in git. It is deterministic, allocation-cheap, and never
+//! writes to the user's repository.
+//!
+//! Two different checkouts of the same repository are deliberately *different*
+//! projects: their graphs live in different slots and must never be merged.
+
+use crate::paths::normalize_workspace;
+use crate::types::ProjectId;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+/// Hex characters kept from the digest. 16 hex chars = 64 bits, which is far
+/// beyond collision range for the number of projects one machine ever indexes.
+const ID_HEX_LEN: usize = 16;
+
+/// How far up the tree we look for a repository marker before giving up.
+const MAX_ANCESTOR_WALK: usize = 64;
+
+/// Nearest enclosing git repository root, or `start` itself when there is none.
+///
+/// Walks up looking for `.git` — a directory in a normal clone, a *file* in a
+/// worktree or submodule, so both are accepted. Does not shell out to `git`, so
+/// it works with no git binary on PATH.
+pub fn project_root(start: &Path) -> PathBuf {
+    let canonical = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
+    let mut current = canonical.as_path();
+    for _ in 0..MAX_ANCESTOR_WALK {
+        if current.join(".git").exists() {
+            return current.to_path_buf();
+        }
+        match current.parent() {
+            Some(parent) => current = parent,
+            None => break,
+        }
+    }
+    canonical
+}
+
+/// Deterministic identity for the project that owns `workspace`.
+///
+/// The digest is taken over [`normalize_workspace`] of the project root, which
+/// is the same normalization the managed-store slot name uses, so an id and its
+/// storage slot always agree about what "the same project" means.
+pub fn stable_project_id(workspace: &Path) -> ProjectId {
+    ProjectId::new(project_id_hex(&project_root(workspace)))
+}
+
+/// Identity for a path that is already known to be a project root — skips the
+/// ancestor walk. Use when the caller resolved the root itself.
+pub fn stable_project_id_for_root(root: &Path) -> ProjectId {
+    ProjectId::new(project_id_hex(root))
+}
+
+fn project_id_hex(root: &Path) -> String {
+    let key = normalize_workspace(root);
+    let digest = Sha256::digest(key.as_bytes());
+    digest
+        .iter()
+        .take(ID_HEX_LEN / 2)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+/// True when `path` lies inside `root`.
+///
+/// Both sides are slash-normalized and lowercased so Windows drive letters and
+/// separators compare correctly. A path equal to `root` counts as inside.
+/// Relative paths never match an absolute root — callers holding the relative
+/// `ContextNode::file_path` should compare project ids instead.
+pub fn path_is_within(path: &Path, root: &Path) -> bool {
+    let root_key = normalize_workspace(root);
+    let path_key = normalize_workspace(path);
+    if path_key == root_key {
+        return true;
+    }
+    let prefix = if root_key.ends_with('/') {
+        root_key
+    } else {
+        format!("{root_key}/")
+    };
+    path_key.starts_with(&prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("nm-pid-{tag}-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn same_path_yields_same_id() {
+        let dir = temp_dir("same");
+        assert_eq!(stable_project_id(&dir), stable_project_id(&dir));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn directory_name_collisions_get_distinct_ids() {
+        // The bug this module exists to fix: two projects both named `app`.
+        let base = temp_dir("collide");
+        let one = base.join("one").join("app");
+        let two = base.join("two").join("app");
+        let _ = fs::create_dir_all(&one);
+        let _ = fs::create_dir_all(&two);
+        assert_ne!(
+            stable_project_id(&one),
+            stable_project_id(&two),
+            "same directory name must not mean same project"
+        );
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn id_is_stable_hex_of_expected_width() {
+        let dir = temp_dir("width");
+        let id = stable_project_id(&dir).0;
+        assert_eq!(id.len(), ID_HEX_LEN);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn subdirectory_resolves_to_the_git_root() {
+        let base = temp_dir("gitroot");
+        let root = base.join("repo");
+        let nested = root.join("crates").join("thing").join("src");
+        let _ = fs::create_dir_all(&nested);
+        let _ = fs::create_dir_all(root.join(".git"));
+
+        assert_eq!(project_root(&nested), project_root(&root));
+        assert_eq!(stable_project_id(&nested), stable_project_id(&root));
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn worktree_git_file_counts_as_a_root() {
+        let base = temp_dir("worktree");
+        let root = base.join("wt");
+        let nested = root.join("src");
+        let _ = fs::create_dir_all(&nested);
+        let _ = fs::write(root.join(".git"), "gitdir: /elsewhere/.git/worktrees/wt");
+
+        assert_eq!(project_root(&nested), project_root(&root));
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn without_git_the_workspace_is_its_own_root() {
+        let base = temp_dir("nogit");
+        let plain = base.join("plain");
+        let _ = fs::create_dir_all(&plain);
+        assert_eq!(project_root(&plain), project_root(&plain));
+        assert_ne!(stable_project_id(&plain), stable_project_id(&base));
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn path_within_root_checks() {
+        let base = temp_dir("within");
+        let root = base.join("root");
+        let inside = root.join("src").join("main.rs");
+        let sibling = base.join("root-other").join("main.rs");
+        let _ = fs::create_dir_all(inside.parent().unwrap());
+        let _ = fs::create_dir_all(sibling.parent().unwrap());
+
+        assert!(path_is_within(&inside, &root));
+        assert!(path_is_within(&root, &root));
+        // `root-other` shares a textual prefix with `root` but is not inside it.
+        assert!(!path_is_within(&sibling, &root));
+        assert!(!path_is_within(Path::new("src/main.rs"), &root));
+        let _ = fs::remove_dir_all(&base);
+    }
+}

--- a/crates/neuromesh-graph/src/graph.rs
+++ b/crates/neuromesh-graph/src/graph.rs
@@ -214,6 +214,99 @@ impl NeuralProjectGraph {
         data.indexed_at = Some(chrono::Utc::now());
     }
 
+    /// Nodes in the mesh that belong to a *different* project than this graph.
+    ///
+    /// `ContextNode::file_path` is relative (`src/main.rs`), so "is this path
+    /// under the workspace root?" cannot separate a leaked node from a
+    /// legitimate one — and two projects very often share relative paths. The
+    /// owning `project_id`, recorded at ingest time, can, with no I/O.
+    ///
+    /// Returns `(foreign project id, relative path)` pairs for reporting.
+    pub fn foreign_nodes(&self) -> Vec<(String, String)> {
+        let current = self.project_id.read().clone();
+        let data = self.inner.read();
+        data.mesh
+            .nodes()
+            .filter(|node| node.project_id != current)
+            .map(|node| {
+                (
+                    node.project_id.to_string(),
+                    node.file_path.to_string_lossy().replace('\\', "/"),
+                )
+            })
+            .collect()
+    }
+
+    /// The single-project invariant: every node belongs to the current project.
+    ///
+    /// Isolation in the baseline is *incidental* — `prune_absent_files` happens
+    /// to drop most of a previous project's nodes on re-index. It does not hold
+    /// when two projects share a relative path whose contents hash identically,
+    /// because `ingest_file_keep` then skips the file and leaves the previous
+    /// project's nodes in place. This turns that into a checked invariant.
+    pub fn assert_single_project(&self) -> std::result::Result<(), Vec<(String, String)>> {
+        let foreign = self.foreign_nodes();
+        if foreign.is_empty() {
+            Ok(())
+        } else {
+            Err(foreign)
+        }
+    }
+
+    /// Drop every node owned by another project, file by file, so the derived
+    /// indexes stay consistent and `file_hashes` loses the stale entry — which
+    /// makes the next scan re-ingest that path for the current project.
+    ///
+    /// Returns the number of files evicted.
+    pub fn evict_foreign_nodes(&self) -> usize {
+        let current = self.project_id.read().clone();
+        let paths: Vec<PathBuf> = {
+            let data = self.inner.read();
+            let mut seen: HashSet<PathBuf> = HashSet::new();
+            for node in data.mesh.nodes() {
+                if node.project_id != current {
+                    seen.insert(node.file_path.clone());
+                }
+            }
+            seen.into_iter().collect()
+        };
+        if paths.is_empty() {
+            return 0;
+        }
+        let mut data = self.inner.write();
+        for path in &paths {
+            remove_file_nodes_locked(&mut data, path);
+        }
+        data.generation = data.generation.saturating_add(1);
+        paths.len()
+    }
+
+    /// Check the single-project invariant and self-heal if it is violated.
+    ///
+    /// Logs at error level with a sample of the offending paths so a leak is
+    /// never silent, then evicts. Returns the number of files evicted.
+    pub fn enforce_single_project(&self) -> usize {
+        let foreign = self.foreign_nodes();
+        if foreign.is_empty() {
+            return 0;
+        }
+        let current = self.project_id.read().clone();
+        let sample: Vec<&str> = foreign
+            .iter()
+            .take(5)
+            .map(|(_, path)| path.as_str())
+            .collect();
+        tracing::error!(
+            nodes = foreign.len(),
+            current_project = %current,
+            ?sample,
+            "cross-project nodes found in graph; evicting"
+        );
+        let evicted = self.evict_foreign_nodes();
+        tracing::warn!(files = evicted, "evicted cross-project files");
+        evicted
+    }
+
     pub fn add_file_node(&self, file: &IndexedFile, content: Option<String>) -> ContextNode {
         let current_pid = self.project_id.read().clone();
         let node = NodeFactory::create_file_node(
@@ -1563,6 +1656,7 @@ impl NeuralProjectGraph {
         match walker.scan_report_with(&self.file_fingerprints()) {
             Ok(report) => {
                 self.ingest_scan_report(&report);
+                self.enforce_single_project();
                 self.inner.write().parser_epoch = GRAPH_PARSER_EPOCH;
                 let _ = self.save_persisted(workspace);
                 #[cfg(feature = "embeddings")]
@@ -1609,9 +1703,16 @@ impl NeuralProjectGraph {
     }
 
     fn ingest_workspace_inner(&self, scanned: &[(IndexedFile, String)], keep_source: bool) {
-        if let Some((file, _)) = scanned.first() {
-            if let Some(root) = infer_workspace_root(file) {
-                self.set_workspace(&root);
+        // Only *infer* a workspace root when nobody has established one. Callers
+        // like `reindex_incremental` already set the authoritative root; letting a
+        // guess taken from the first file of the batch overwrite it made the root
+        // drift, which matters inside a monorepo where the guess can land on a
+        // nested package.
+        if self.workspace_root().is_none() {
+            if let Some((file, _)) = scanned.first() {
+                if let Some(root) = infer_workspace_root(file) {
+                    self.set_workspace(&root);
+                }
             }
         }
         let parsed: Vec<_> = scanned

--- a/crates/neuromesh-graph/src/graph.rs
+++ b/crates/neuromesh-graph/src/graph.rs
@@ -82,6 +82,17 @@ pub enum IndexState {
     Failed,
 }
 
+/// Outcome of reconciling a loaded snapshot's project id with the current one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectIdReconciliation {
+    /// Every node already belongs to the current project, or the graph is empty.
+    AlreadyCurrent,
+    /// The snapshot carried a single older id; that many nodes were re-stamped.
+    Restamped(usize),
+    /// The snapshot carried several ids — a real leak. Nothing was re-stamped.
+    Mixed(usize),
+}
+
 struct IndexGate {
     state: Mutex<IndexState>,
     cv: Condvar,
@@ -279,6 +290,45 @@ impl NeuralProjectGraph {
         }
         data.generation = data.generation.saturating_add(1);
         paths.len()
+    }
+
+    /// Reconcile the project id carried by a freshly loaded snapshot.
+    ///
+    /// A persisted snapshot always comes from a single project slot. When every
+    /// node carries one and the same *older* id — a graph written before ids
+    /// were derived from the project path, say — re-stamping is correct and
+    /// avoids throwing away a valid index for a full re-scan.
+    ///
+    /// A snapshot holding *several* ids is genuinely contaminated. That case is
+    /// reported, not re-stamped, and left to `enforce_single_project`:
+    /// re-stamping there would launder a real leak into looking clean.
+    pub fn reconcile_loaded_project_id(&self) -> ProjectIdReconciliation {
+        let current = self.project_id.read().clone();
+        let mut data = self.inner.write();
+
+        let mut foreign_ids: HashSet<ProjectId> = HashSet::new();
+        let mut foreign_nodes = 0usize;
+        for node in data.mesh.nodes() {
+            if node.project_id != current {
+                foreign_nodes += 1;
+                foreign_ids.insert(node.project_id.clone());
+            }
+        }
+
+        if foreign_nodes == 0 {
+            return ProjectIdReconciliation::AlreadyCurrent;
+        }
+        if foreign_ids.len() > 1 {
+            return ProjectIdReconciliation::Mixed(foreign_nodes);
+        }
+
+        for node in data.mesh.nodes_mut() {
+            node.project_id = current.clone();
+        }
+        for edge in data.mesh.edges_mut() {
+            edge.project_id = current.clone();
+        }
+        ProjectIdReconciliation::Restamped(foreign_nodes)
     }
 
     /// Check the single-project invariant and self-heal if it is violated.
@@ -1555,6 +1605,22 @@ impl NeuralProjectGraph {
             self.load_from(&Self::persist_json_path(workspace))
                 .unwrap_or(false)
         };
+        if loaded {
+            // A stored graph belongs to exactly one project, but the id it
+            // recorded can predate path-derived ids. Reconcile before anything
+            // checks the invariant, or `enforce_single_project` would evict a
+            // perfectly good index and force a full re-scan.
+            match self.reconcile_loaded_project_id() {
+                ProjectIdReconciliation::Restamped(nodes) => {
+                    tracing::info!(nodes, "re-stamped stored graph onto current project id");
+                }
+                ProjectIdReconciliation::Mixed(nodes) => {
+                    // Left dirty on purpose: eviction, not laundering.
+                    tracing::error!(nodes, "stored graph holds several projects");
+                }
+                ProjectIdReconciliation::AlreadyCurrent => {}
+            }
+        }
         if loaded && self.stats().total_nodes > 0 {
             self.mark_index_ready();
         }

--- a/crates/neuromesh-graph/src/intern.rs
+++ b/crates/neuromesh-graph/src/intern.rs
@@ -285,6 +285,12 @@ impl MeshStore {
         self.edges.iter_mut().filter_map(|e| e.as_mut())
     }
 
+    /// Bumps `node_revision` up front, since the caller may mutate any node.
+    pub fn nodes_mut(&mut self) -> impl Iterator<Item = &mut ContextNode> {
+        self.node_revision = self.node_revision.wrapping_add(1);
+        self.nodes.iter_mut().filter_map(|n| n.as_mut())
+    }
+
     #[allow(dead_code)]
     pub fn node_ids(&self) -> impl Iterator<Item = &NodeId> {
         self.node_of.keys()

--- a/crates/neuromesh-graph/src/isolation_tests.rs
+++ b/crates/neuromesh-graph/src/isolation_tests.rs
@@ -1,0 +1,146 @@
+#[cfg(test)]
+mod tests {
+    use crate::NeuralProjectGraph;
+    use neuromesh_core::ProjectId;
+    use neuromesh_index::{IndexedFile, SourceLanguage};
+    use neuromesh_parser::CodeIntelligenceEngine;
+    use std::path::{Path, PathBuf};
+
+    fn indexed(rel: &str, hash: &str) -> IndexedFile {
+        IndexedFile {
+            project_id: ProjectId::new("ignored-by-graph"),
+            relative_path: PathBuf::from(rel),
+            full_path: PathBuf::from(rel),
+            blake3_hash: hash.into(),
+            byte_size: 100,
+            token_count: 80,
+            language: SourceLanguage::Rust,
+            last_modified: chrono::Utc::now(),
+        }
+    }
+
+    fn ingest(graph: &NeuralProjectGraph, rel: &str, hash: &str, src: &str) {
+        let path = PathBuf::from(rel);
+        graph.ingest_file(
+            &indexed(rel, hash),
+            &CodeIntelligenceEngine::analyze(&path, src, SourceLanguage::Rust),
+            Some(src),
+        );
+    }
+
+    const SHARED: &str = "pub fn shared_helper() -> usize { 42 }\n";
+
+    #[test]
+    fn a_clean_single_project_graph_satisfies_the_invariant() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("project-a"));
+        ingest(&graph, "src/lib.rs", "hash-a", SHARED);
+        ingest(&graph, "src/only_in_a.rs", "hash-b", "pub fn only_a() {}\n");
+
+        assert_eq!(graph.assert_single_project(), Ok(()));
+        assert_eq!(graph.foreign_nodes().len(), 0);
+        assert_eq!(graph.enforce_single_project(), 0);
+    }
+
+    /// The real leak path (design doc case "A2").
+    ///
+    /// `ingest_file_keep` returns early when the stored hash for a relative path
+    /// equals the incoming hash. Two projects very often share a relative path
+    /// *and* its exact contents — `LICENSE`, `.gitignore`, an empty
+    /// `__init__.py`, boilerplate config. When that happens after a project
+    /// switch the new project's file is never ingested and the previous
+    /// project's nodes stay in the graph, still tagged with its `project_id`.
+    #[test]
+    fn identical_shared_path_leaks_nodes_across_a_project_switch() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("project-a"));
+        ingest(&graph, "src/lib.rs", "identical", SHARED);
+
+        // What `adopt_workspace_from_initialize` does on a workspace change.
+        graph.set_project_id(ProjectId::new("project-b"));
+        // Project B has the same relative path with byte-identical contents.
+        ingest(&graph, "src/lib.rs", "identical", SHARED);
+
+        let foreign = graph
+            .assert_single_project()
+            .expect_err("project-a nodes must still be detectable after the switch");
+        assert!(
+            foreign
+                .iter()
+                .any(|(pid, path)| pid == "project-a" && path == "src/lib.rs"),
+            "expected a project-a node at src/lib.rs, got {foreign:?}"
+        );
+    }
+
+    #[test]
+    fn enforcing_the_invariant_evicts_foreign_nodes_and_clears_their_hash() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("project-a"));
+        ingest(&graph, "src/lib.rs", "identical", SHARED);
+        ingest(&graph, "src/only_in_a.rs", "hash-b", "pub fn only_a() {}\n");
+
+        graph.set_project_id(ProjectId::new("project-b"));
+        assert!(graph.assert_single_project().is_err());
+
+        let evicted = graph.enforce_single_project();
+        assert_eq!(evicted, 2, "both project-a files should be evicted");
+        assert_eq!(graph.assert_single_project(), Ok(()));
+
+        // The stale hashes must be gone, otherwise the next scan would skip
+        // these paths again and the leak would silently return.
+        let hashes = graph.file_hashes();
+        assert!(!hashes.contains_key("src/lib.rs"));
+        assert!(!hashes.contains_key("src/only_in_a.rs"));
+    }
+
+    #[test]
+    fn eviction_leaves_the_current_projects_nodes_alone() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("project-a"));
+        ingest(&graph, "src/stale.rs", "hash-a", "pub fn stale() {}\n");
+
+        graph.set_project_id(ProjectId::new("project-b"));
+        ingest(&graph, "src/fresh.rs", "hash-b", "pub fn fresh() {}\n");
+
+        assert_eq!(graph.enforce_single_project(), 1);
+        let hashes = graph.file_hashes();
+        assert!(hashes.contains_key("src/fresh.rs"), "current project kept");
+        assert!(
+            !hashes.contains_key("src/stale.rs"),
+            "foreign project dropped"
+        );
+    }
+
+    /// P0-5: an authoritative workspace root must survive ingest.
+    ///
+    /// `ingest_workspace_inner` used to overwrite `workspace_root` with a guess
+    /// derived from the first file of the batch, undoing the root that
+    /// `reindex_incremental` had just set. Inside a monorepo that guess can land
+    /// on a nested package.
+    #[test]
+    fn ingest_does_not_overwrite_an_explicit_workspace_root() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("project-a"));
+        let authoritative = PathBuf::from("/authoritative/root");
+        graph.set_workspace(&authoritative);
+
+        let mut file = indexed("src/main.rs", "hash-a");
+        file.full_path = PathBuf::from("/guessed/elsewhere/src/main.rs");
+        graph.ingest_workspace(&[(file, "pub fn main() {}\n".to_string())]);
+
+        assert_eq!(
+            graph.workspace_root().as_deref(),
+            Some(authoritative.as_path())
+        );
+    }
+
+    #[test]
+    fn ingest_still_infers_a_root_when_none_was_set() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("project-a"));
+        assert!(graph.workspace_root().is_none());
+
+        let mut file = indexed("src/main.rs", "hash-a");
+        file.full_path = PathBuf::from("/inferred/root/src/main.rs");
+        graph.ingest_workspace(&[(file, "pub fn main() {}\n".to_string())]);
+
+        assert_eq!(
+            graph.workspace_root().as_deref(),
+            Some(Path::new("/inferred/root"))
+        );
+    }
+}

--- a/crates/neuromesh-graph/src/isolation_tests.rs
+++ b/crates/neuromesh-graph/src/isolation_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::NeuralProjectGraph;
+    use crate::{NeuralProjectGraph, ProjectIdReconciliation};
     use neuromesh_core::ProjectId;
     use neuromesh_index::{IndexedFile, SourceLanguage};
     use neuromesh_parser::CodeIntelligenceEngine;
@@ -105,6 +105,62 @@ mod tests {
             !hashes.contains_key("src/stale.rs"),
             "foreign project dropped"
         );
+    }
+
+    #[test]
+    fn reconcile_is_a_noop_for_a_graph_already_on_the_current_project() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("project-a"));
+        ingest(&graph, "src/lib.rs", "hash-a", SHARED);
+
+        assert_eq!(
+            graph.reconcile_loaded_project_id(),
+            ProjectIdReconciliation::AlreadyCurrent
+        );
+    }
+
+    /// A stored graph written before ids were derived from the project path
+    /// carries one uniform, now-stale id. Re-stamping keeps a valid index
+    /// instead of forcing a full re-scan.
+    #[test]
+    fn reconcile_restamps_a_uniformly_stale_snapshot() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("app"));
+        ingest(&graph, "src/lib.rs", "hash-a", SHARED);
+        ingest(&graph, "src/other.rs", "hash-b", "pub fn other() {}\n");
+
+        // What loading that snapshot under a path-derived id looks like.
+        graph.set_project_id(ProjectId::new("9f2c1ab4d0e5f671"));
+
+        let outcome = graph.reconcile_loaded_project_id();
+        assert!(
+            matches!(outcome, ProjectIdReconciliation::Restamped(n) if n > 0),
+            "expected a re-stamp, got {outcome:?}"
+        );
+        assert_eq!(graph.assert_single_project(), Ok(()));
+        // The index survived: re-stamping must not drop files.
+        let hashes = graph.file_hashes();
+        assert!(hashes.contains_key("src/lib.rs"));
+        assert!(hashes.contains_key("src/other.rs"));
+    }
+
+    /// Several ids in one snapshot is a genuine leak, not a stale id. Laundering
+    /// it by re-stamping would make a contaminated graph look clean.
+    #[test]
+    fn reconcile_refuses_to_launder_a_mixed_snapshot() {
+        let graph = NeuralProjectGraph::new(ProjectId::new("project-a"));
+        ingest(&graph, "src/a.rs", "hash-a", "pub fn a() {}\n");
+        graph.set_project_id(ProjectId::new("project-b"));
+        ingest(&graph, "src/b.rs", "hash-b", "pub fn b() {}\n");
+        graph.set_project_id(ProjectId::new("project-c"));
+
+        let outcome = graph.reconcile_loaded_project_id();
+        assert!(
+            matches!(outcome, ProjectIdReconciliation::Mixed(n) if n > 0),
+            "expected mixed, got {outcome:?}"
+        );
+        // Left dirty on purpose, for the eviction path to deal with.
+        assert!(graph.assert_single_project().is_err());
+        assert_eq!(graph.enforce_single_project(), 2);
+        assert_eq!(graph.assert_single_project(), Ok(()));
     }
 
     /// P0-5: an authoritative workspace root must survive ingest.

--- a/crates/neuromesh-graph/src/lib.rs
+++ b/crates/neuromesh-graph/src/lib.rs
@@ -11,6 +11,8 @@ pub mod query;
 pub mod synapse;
 
 #[cfg(test)]
+mod isolation_tests;
+#[cfg(test)]
 mod quality_tests;
 #[cfg(test)]
 mod repo_quality_tests;

--- a/crates/neuromesh-graph/src/lib.rs
+++ b/crates/neuromesh-graph/src/lib.rs
@@ -30,7 +30,7 @@ pub use embeddings::{
 pub use embeddings::{load_sidecar, EmbeddingIndex, EmbeddingSidecar};
 pub use graph::{
     node_learning_bonus, path_echoes_symbol, GraphStats, IndexState, NeuralProjectGraph,
-    NodeLearningProfile, GRAPH_PARSER_EPOCH,
+    NodeLearningProfile, ProjectIdReconciliation, GRAPH_PARSER_EPOCH,
 };
 pub use node::NodeFactory;
 pub use physarum::{PhysarumConfig, PhysarumResult, PhysarumSolver};

--- a/crates/neuromesh-index/src/walker.rs
+++ b/crates/neuromesh-index/src/walker.rs
@@ -194,6 +194,19 @@ impl ProjectWalker {
         crate::confine::is_safe_workspace(path)
     }
 
+    /// True when `path` sits in an ignored directory *of this project*.
+    ///
+    /// `is_ignored` inspects every component of whatever it is handed, so
+    /// passing an absolute path also inspects the directories *above* the
+    /// workspace. A project that legitimately lives under a folder named
+    /// `build`, `dist`, `vendor`, `target` — or, on Windows, anywhere beneath
+    /// `AppData`, which is where `std::env::temp_dir()` points — then has every
+    /// one of its files filtered out and indexes to nothing. Only the part
+    /// below the workspace root describes the project's own structure.
+    pub fn is_ignored_within(root: &Path, path: &Path) -> bool {
+        Self::is_ignored(path.strip_prefix(root).unwrap_or(path))
+    }
+
     pub fn is_ignored(path: &Path) -> bool {
         for component in path.components() {
             let s = component.as_os_str().to_string_lossy();
@@ -278,11 +291,12 @@ impl ProjectWalker {
 
         let mut candidates: Vec<(PathBuf, PathBuf, u64, DateTime<Utc>)> = Vec::new();
 
+        let walk_root = self.root_path.clone();
         for entry in WalkDir::new(&self.root_path)
             .max_depth(10)
             .follow_links(false)
             .into_iter()
-            .filter_entry(|e| !Self::is_ignored(e.path()))
+            .filter_entry(|e| !Self::is_ignored_within(&walk_root, e.path()))
             .filter_map(|e| e.ok())
         {
             if !entry.file_type().is_file() {
@@ -377,7 +391,7 @@ impl ProjectWalker {
 
     /// Read one workspace file for the live watcher.
     pub fn read_indexed(&self, full_path: &Path) -> Option<(IndexedFile, String)> {
-        if Self::is_ignored(full_path) {
+        if Self::is_ignored_within(&self.root_path, full_path) {
             return None;
         }
         if crate::confine::path_escapes_workspace(full_path, &self.root_path) {
@@ -652,6 +666,33 @@ mod tests {
             .ends_with("src/a.rs"));
         assert_eq!(third.unchanged, 1);
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn directories_above_the_workspace_do_not_make_everything_ignored() {
+        // A project that happens to live under `build`, `dist`, `vendor`, or —
+        // on Windows — anywhere under `AppData` (where temp_dir() points) must
+        // still index. Only its own subdirectories count.
+        let root = Path::new("C:/Users/x/AppData/Local/Temp/my-app");
+        assert!(
+            !ProjectWalker::is_ignored_within(root, &root.join("src/main.rs")),
+            "an ignored component above the root must not filter the project out"
+        );
+        let vendored = Path::new("/home/x/vendor/my-app");
+        assert!(!ProjectWalker::is_ignored_within(
+            vendored,
+            &vendored.join("src/lib.rs")
+        ));
+
+        // The project's *own* ignored directories still count.
+        assert!(ProjectWalker::is_ignored_within(
+            root,
+            &root.join("node_modules/pkg/index.js")
+        ));
+        assert!(ProjectWalker::is_ignored_within(
+            vendored,
+            &vendored.join("target/debug/build.rs")
+        ));
     }
 
     #[test]

--- a/crates/neuromesh-index/src/walker.rs
+++ b/crates/neuromesh-index/src/walker.rs
@@ -87,6 +87,30 @@ impl ProjectWalker {
         self
     }
 
+    /// True when this directory looks like the root of a project.
+    ///
+    /// Same set `discover_workspace` walks up looking for, exposed so callers
+    /// can ask "is this a project at all?" without walking.
+    pub fn has_project_marker(dir: &Path) -> bool {
+        dir.join(".git").exists()
+            || dir.join("Cargo.toml").exists()
+            || dir.join("package.json").exists()
+            || dir.join("pyproject.toml").exists()
+            || dir.join("settings.gradle.kts").exists()
+            || dir.join("settings.gradle").exists()
+            || dir.join("pubspec.yaml").exists()
+            || dir.join("Package.swift").exists()
+            || dir.join("Gemfile").exists()
+            || dir.join("composer.json").exists()
+            || dir.join("artisan").exists()
+            || dir.join("manage.py").exists()
+            || dir.join("app.php").exists()
+            || dir.join("bin").join("pinx").exists()
+            || dir.join("go.mod").exists()
+            || dir.join("angular.json").exists()
+            || dir.join("App.csproj").exists()
+    }
+
     /// Walk up from `start` to a git/cargo root, refusing home and drive roots.
     pub fn discover_workspace(start: &Path) -> PathBuf {
         let mut current = start.to_path_buf();
@@ -94,24 +118,7 @@ impl ProjectWalker {
             if !Self::is_safe_workspace(&current) {
                 break;
             }
-            if current.join(".git").exists()
-                || current.join("Cargo.toml").exists()
-                || current.join("package.json").exists()
-                || current.join("pyproject.toml").exists()
-                || current.join("settings.gradle.kts").exists()
-                || current.join("settings.gradle").exists()
-                || current.join("pubspec.yaml").exists()
-                || current.join("Package.swift").exists()
-                || current.join("Gemfile").exists()
-                || current.join("composer.json").exists()
-                || current.join("artisan").exists()
-                || current.join("manage.py").exists()
-                || current.join("app.php").exists()
-                || current.join("bin").join("pinx").exists()
-                || current.join("go.mod").exists()
-                || current.join("angular.json").exists()
-                || current.join("App.csproj").exists()
-            {
+            if Self::has_project_marker(&current) {
                 return current;
             }
             match current.parent() {
@@ -120,6 +127,50 @@ impl ProjectWalker {
             }
         }
         start.to_path_buf()
+    }
+
+    /// Why `path` must not be indexed at all, or `None` when it is usable.
+    ///
+    /// Safety only — it deliberately does *not* require a project marker,
+    /// because an explicitly given path is the user telling us where to look.
+    /// `explicit_workspace` supports pointing at a nested folder with no
+    /// manifest, and that must keep working.
+    pub fn workspace_rejection_reason(path: &Path) -> Option<String> {
+        if !path.exists() {
+            return Some(format!("{} does not exist", path.display()));
+        }
+        if !path.is_dir() {
+            return Some(format!("{} is not a directory", path.display()));
+        }
+        if !Self::is_safe_workspace(path) {
+            return Some(format!(
+                "{} is a home, drive, or system directory",
+                path.display()
+            ));
+        }
+        None
+    }
+
+    /// Same, plus a project marker — for a root that was *guessed* rather than
+    /// given.
+    ///
+    /// `discover_workspace` falls back to its starting point when the walk up
+    /// finds no marker, so a server started with no workspace path, no
+    /// `NEUROMESH_WORKSPACE`, and no IDE env would happily index whatever sat
+    /// in the current directory. That is the "binds to your home directory and
+    /// indexes unrelated projects" failure the docs warn about. A guess with no
+    /// project in it is not worth indexing; an explicit path still is.
+    pub fn discovered_workspace_rejection_reason(path: &Path) -> Option<String> {
+        if let Some(reason) = Self::workspace_rejection_reason(path) {
+            return Some(reason);
+        }
+        if !Self::has_project_marker(path) {
+            return Some(format!(
+                "{} has no project marker (.git, Cargo.toml, package.json, pyproject.toml, go.mod, composer.json, …)",
+                path.display()
+            ));
+        }
+        None
     }
 
     /// Honor an explicit MCP/CLI directory instead of walking to a parent git root.
@@ -601,6 +652,58 @@ mod tests {
             .ends_with("src/a.rs"));
         assert_eq!(third.unchanged, 1);
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_directory_with_no_project_marker_is_refused() {
+        let root = std::env::temp_dir().join(format!("nm-reject-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("notes")).unwrap();
+        fs::write(root.join("notes/todo.txt"), "buy milk\n").unwrap();
+
+        assert!(!ProjectWalker::has_project_marker(&root));
+        let reason = ProjectWalker::discovered_workspace_rejection_reason(&root)
+            .expect("a guessed marker-less directory must be refused");
+        assert!(
+            reason.contains("no project marker"),
+            "unexpected reason: {reason}"
+        );
+        // An explicitly given path is still allowed to have no manifest.
+        assert_eq!(ProjectWalker::workspace_rejection_reason(&root), None);
+
+        // One marker is enough to make it a project.
+        fs::write(root.join("package.json"), "{}\n").unwrap();
+        assert!(ProjectWalker::has_project_marker(&root));
+        assert_eq!(
+            ProjectWalker::discovered_workspace_rejection_reason(&root),
+            None
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn missing_paths_and_files_are_refused() {
+        let missing = std::env::temp_dir().join("nm-definitely-not-here-zzzz");
+        assert!(ProjectWalker::workspace_rejection_reason(&missing)
+            .is_some_and(|r| r.contains("does not exist")));
+
+        let file = std::env::temp_dir().join(format!("nm-not-a-dir-{}.txt", std::process::id()));
+        fs::write(&file, "x").unwrap();
+        assert!(ProjectWalker::workspace_rejection_reason(&file)
+            .is_some_and(|r| r.contains("not a directory")));
+        let _ = fs::remove_file(&file);
+    }
+
+    #[test]
+    fn the_home_directory_is_refused() {
+        if let Some(home) = dirs::home_dir() {
+            let reason = ProjectWalker::workspace_rejection_reason(&home);
+            assert!(
+                reason.is_some(),
+                "the home directory must never be indexable"
+            );
+        }
     }
 
     #[test]

--- a/crates/neuromesh-index/src/watcher.rs
+++ b/crates/neuromesh-index/src/watcher.rs
@@ -97,7 +97,7 @@ fn collect_event(
 ) {
     let is_delete = matches!(event.kind, EventKind::Remove(_));
     for path in event.paths {
-        if ProjectWalker::is_ignored(&path) {
+        if ProjectWalker::is_ignored_within(root, &path) {
             continue;
         }
         if crate::confine::path_escapes_workspace(&path, root) {

--- a/crates/neuromesh-mcp/src/server.rs
+++ b/crates/neuromesh-mcp/src/server.rs
@@ -145,23 +145,30 @@ impl McpServer {
         if !p_buf.exists() || !neuromesh_index::ProjectWalker::is_safe_workspace(&p_buf) {
             return;
         }
-        if neuromesh_index::same_workspace_path(
-            self.handler.graph().workspace_root().as_deref(),
-            &p_buf,
-        ) {
+        let graph = self.handler.graph();
+        let pid = neuromesh_core::stable_project_id(&p_buf);
+        // Skip only a genuine no-op: same project identity *and* same root.
+        // Comparing paths alone served the previous project's graph whenever
+        // workspace discovery collapsed two projects onto one directory, and the
+        // old id was the workspace *directory name*, so unrelated checkouts both
+        // called `app` compared equal.
+        let same_root =
+            neuromesh_index::same_workspace_path(graph.workspace_root().as_deref(), &p_buf);
+        if same_root && graph.project_id() == pid {
             return;
         }
-        let p_name = p_buf
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "project".to_string());
-        let pid = neuromesh_core::ProjectId::new(&p_name);
-        self.handler.graph().set_project_id(pid.clone());
-        self.handler.graph().set_workspace(&p_buf);
-        let _ = self.handler.graph().load_persisted(&p_buf);
+
+        // A real switch. Drop the previous project's graph up front: leaving it
+        // to `prune_absent_files` during re-index kept nodes for every path the
+        // two projects happened to share byte-for-byte.
+        graph.clear(Some(pid.clone()));
+        graph.set_workspace(&p_buf);
+        // `load_persisted` reconciles the stored project id itself; anything it
+        // cannot reconcile is evicted by the guard after the re-index below.
+        let _ = graph.load_persisted(&p_buf);
         self.handler.warmup_persisted_learning();
-        if self.handler.graph().stats().total_nodes == 0 {
-            self.handler.graph().mark_index_loading();
+        if graph.stats().total_nodes == 0 {
+            graph.mark_index_loading();
         }
         let bg_graph = self.handler.graph().clone();
         let bg_dir = p_buf.clone();

--- a/crates/neuromesh-mcp/src/server.rs
+++ b/crates/neuromesh-mcp/src/server.rs
@@ -163,6 +163,23 @@ impl McpServer {
         // two projects happened to share byte-for-byte.
         graph.clear(Some(pid.clone()));
         graph.set_workspace(&p_buf);
+
+        // The memory store has to follow the project too. The handler is built
+        // once, for the startup workspace; leaving it pinned wrote this
+        // project's episodes into the previous project's `neuromesh.json` and
+        // hid this project's own memory, since every read filters by project id.
+        // The warmup below reads from it, so swap first.
+        let db_path = neuromesh_core::memory_db_path(&p_buf);
+        if let Ok(db) = neuromesh_memory::MemoryDatabase::open(&db_path)
+            .or_else(|_| neuromesh_memory::MemoryDatabase::open_in_memory())
+        {
+            let db = std::sync::Arc::new(db);
+            for fact in neuromesh_memory::extract_project_facts(&p_buf, &pid) {
+                let _ = db.save_project_fact(&fact);
+            }
+            self.handler.swap_memory_db(db);
+        }
+
         // `load_persisted` reconciles the stored project id itself; anything it
         // cannot reconcile is evicted by the guard after the re-index below.
         let _ = graph.load_persisted(&p_buf);

--- a/crates/neuromesh-mcp/src/server.rs
+++ b/crates/neuromesh-mcp/src/server.rs
@@ -142,9 +142,7 @@ impl McpServer {
         } else {
             neuromesh_index::ProjectWalker::discover_workspace(&raw)
         };
-        if let Some(reason) =
-            neuromesh_index::ProjectWalker::workspace_rejection_reason(&p_buf)
-        {
+        if let Some(reason) = neuromesh_index::ProjectWalker::workspace_rejection_reason(&p_buf) {
             eprintln!("NeuroMesh refused the workspace from initialize: {reason}");
             return;
         }

--- a/crates/neuromesh-mcp/src/server.rs
+++ b/crates/neuromesh-mcp/src/server.rs
@@ -142,7 +142,10 @@ impl McpServer {
         } else {
             neuromesh_index::ProjectWalker::discover_workspace(&raw)
         };
-        if !p_buf.exists() || !neuromesh_index::ProjectWalker::is_safe_workspace(&p_buf) {
+        if let Some(reason) =
+            neuromesh_index::ProjectWalker::workspace_rejection_reason(&p_buf)
+        {
+            eprintln!("NeuroMesh refused the workspace from initialize: {reason}");
             return;
         }
         let graph = self.handler.graph();

--- a/crates/neuromesh-mcp/src/tools.rs
+++ b/crates/neuromesh-mcp/src/tools.rs
@@ -33,7 +33,9 @@ pub struct McpToolHandler {
     graph: Arc<NeuralProjectGraph>,
     activator: Arc<ContextActivator>,
     expansion_engine: Arc<ExpansionEngine>,
-    memory_db: Arc<MemoryDatabase>,
+    /// Swappable: the handler outlives a workspace change, and the store must
+    /// follow the project rather than stay pinned to the startup workspace.
+    memory_store: RwLock<Arc<MemoryDatabase>>,
     working_memory: Arc<parking_lot::RwLock<WorkingMemory>>,
     mycelium: Arc<MyceliumCache>,
     packet_cache: PacketDetailCache,
@@ -92,7 +94,7 @@ impl McpToolHandler {
             graph,
             activator,
             expansion_engine,
-            memory_db,
+            memory_store: RwLock::new(memory_db),
             working_memory,
             mycelium: Arc::new(MyceliumCache::new(MyceliumConfig::default())),
             packet_cache: PacketDetailCache::new(),
@@ -147,13 +149,28 @@ impl McpToolHandler {
         *self.client_id.write() = Some(client);
     }
 
+    fn memory_db(&self) -> Arc<MemoryDatabase> {
+        self.memory_store.read().clone()
+    }
+
+    /// Point the memory store at a different project's slot.
+    ///
+    /// The handler is built once, for the startup workspace, but MCP clients
+    /// hand the real workspace over in `initialize` and may later switch.
+    /// Leaving the store pinned wrote the new project's episodes into the
+    /// previous project's `neuromesh.json`, and hid the new project's own
+    /// memory, because every read filters by the (now different) project id.
+    pub fn swap_memory_db(&self, db: Arc<MemoryDatabase>) {
+        *self.memory_store.write() = db;
+    }
+
     pub fn graph(&self) -> &Arc<NeuralProjectGraph> {
         &self.graph
     }
 
     pub fn warmup_persisted_learning(&self) {
         let pid = self.graph.project_id();
-        let _ = crate::learning::warmup_project_learning(&self.memory_db, &self.graph, &pid);
+        let _ = crate::learning::warmup_project_learning(&self.memory_db(), &self.graph, &pid);
     }
 
     pub fn persist_project_state(&self) {
@@ -295,7 +312,7 @@ impl McpToolHandler {
                     apply_server_assisted_defaults(&mut signature, &task_desc, auto_extract);
                 if requested_mode == neuromesh_core::OptimizationMode::MaxQuality {
                     if let Ok(episodes) = self
-                        .memory_db
+                        .memory_db()
                         .find_similar_episodes(&self.graph.project_id(), &task_desc)
                     {
                         for ep in episodes.into_iter().filter(|e| e.success).take(3) {
@@ -915,7 +932,7 @@ impl McpToolHandler {
 
                 let pid = self.graph.project_id();
                 let learning_episodes_in_store = self
-                    .memory_db
+                    .memory_db()
                     .list_project_episodes(&pid)
                     .map(|eps| eps.len())
                     .unwrap_or(0);
@@ -937,7 +954,7 @@ impl McpToolHandler {
                         0,
                     );
                     episode_id = episode.id.clone();
-                    let _ = self.memory_db.save_episodic_record(&episode);
+                    let _ = self.memory_db().save_episodic_record(&episode);
                 }
                 if !episode_id.is_empty() {
                     self.graph.mark_learning_episode_applied(&episode_id);
@@ -972,7 +989,7 @@ impl McpToolHandler {
             "neuromesh_get_project_memory" => {
                 let start_time = std::time::Instant::now();
                 let pid = self.graph.project_id();
-                let facts = self.memory_db.get_project_facts(&pid)?;
+                let facts = self.memory_db().get_project_facts(&pid)?;
                 self.emit_telemetry(ToolTelemetry {
                     nodes_after: facts.len(),
                     latency_ms: start_time.elapsed().as_millis() as u64,
@@ -993,7 +1010,7 @@ impl McpToolHandler {
                     .or_else(|| arguments["task_similarity_query"].as_str())
                     .unwrap_or("");
                 let pid = self.graph.project_id();
-                let episodes = self.memory_db.find_similar_episodes(&pid, query)?;
+                let episodes = self.memory_db().find_similar_episodes(&pid, query)?;
                 self.emit_telemetry(ToolTelemetry {
                     nodes_after: episodes.len(),
                     latency_ms: start_time.elapsed().as_millis() as u64,

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Start with the [README](../README.md) for install and the agent loop.
 | [Configuration](configuration.md) | Engine presets, proxy, env vars, monitor, file cap, build from source |
 | [Engines](engines.md) | Quick overview of `fast` / `hybrid` / `deep` |
 | [Architecture](architecture.md) | Pipeline, tiered retrieval, crate map |
+| [Isolation](isolation.md) | Project identity, the single-project invariant, what will not be indexed |
 | [Quality](quality.md) | Gold harness, `neuromesh eval`, release gates, measured numbers |
 | [Graph proxy](graph-proxy.md) | Optional CBM backend via MCP stdio |
 | [HTTP monitor](api.md) | Local UI, SSE, management endpoints |

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -1,0 +1,128 @@
+# Project isolation
+
+One runtime, many projects, no bleed. This page describes how a project is
+identified, what guarantees the graph makes, and what it refuses to index.
+
+## Project identity
+
+A `ProjectId` is a pure function of the canonical path of the **project root** —
+the nearest enclosing git repository, or the workspace itself when it is not in
+git:
+
+```
+ProjectId = sha256(normalize_workspace(project_root))[..16 hex]
+```
+
+It is derived the same way everywhere: the MCP server, every CLI command, and
+the monitor's HTTP server. Nothing is written into your repository to compute
+it, and no `git` binary is required (a `.git` file from a worktree or submodule
+counts as well as a directory).
+
+Consequences worth knowing:
+
+| Situation | Result |
+| :--- | :--- |
+| You open the repo root | The repo's id |
+| You open a subdirectory of the repo | **The same** id — a subdirectory is the same project |
+| Two checkouts of the same repo in different paths | **Different** ids, different graphs |
+| Two unrelated projects whose folders are both named `app` | **Different** ids |
+| A monorepo with several packages | One id, one graph (see [Monorepos](#monorepos)) |
+
+Storage follows identity: each project gets its own slot under
+`~/.neuromesh/projects/<name>-<hash>/` holding `graph.bin`, `embeddings.bin`,
+`neuromesh.json`, and `config.json`. See [configuration.md](configuration.md)
+for the `managed` / `local` store modes.
+
+## The single-project invariant
+
+> Every node in a live graph belongs to the graph's current project.
+
+Every `ContextNode` records the project it was ingested for, so the check is
+exact and costs no disk access. It runs after each re-index:
+
+- `assert_single_project()` — reports offenders as `(project id, path)` pairs
+- `evict_foreign_nodes()` — drops them file by file, which also clears their
+  `file_hashes` entry so the next scan re-ingests the path for the *current*
+  project instead of skipping it
+- `enforce_single_project()` — logs at error level with a sample, then evicts
+
+Why this is needed rather than assumed: re-indexing prunes paths that are absent
+from the new scan, which removes most of a previous project's nodes on its own.
+But `ingest_file_keep` returns early when a path's stored hash equals the
+incoming hash, and two projects very often share a relative path *and* its exact
+bytes — `LICENSE`, `.gitignore`, an empty `__init__.py`, boilerplate config. For
+those, the previous project's nodes would survive. The invariant closes that gap
+instead of relying on the coincidence that paths differ.
+
+### Loading a stored graph
+
+A `graph.bin` belongs to exactly one project, but the id it recorded may be
+stale — written before ids were derived from the path, say.
+`reconcile_loaded_project_id` runs inside `load_persisted` and distinguishes:
+
+| Snapshot | Outcome |
+| :--- | :--- |
+| All nodes carry the current id | `AlreadyCurrent` — nothing to do |
+| All nodes carry **one** older id | `Restamped` — re-stamped, index preserved |
+| Nodes carry **several** ids | `Mixed` — a real leak; deliberately *not* re-stamped, left for eviction |
+
+Re-stamping a mixed snapshot would launder a contaminated graph into looking
+clean, so it is refused.
+
+## Switching projects
+
+When an MCP client hands over a workspace in `initialize`, the server skips work
+only when it is a genuine no-op — **same project id *and* same root**. Comparing
+paths alone was not enough: workspace discovery can collapse two projects onto
+one directory, and the old directory-name id made unrelated checkouts compare
+equal.
+
+A real switch clears the graph first, then points the memory store at the new
+project's slot, loads any stored graph, and re-indexes. The memory store follows
+the project because episodes and project facts are keyed by project id; leaving
+it pinned wrote the new project's memory into the previous project's file.
+
+## What will not be indexed
+
+`is_safe_workspace` refuses home, drive, and system directories. On top of that,
+a workspace root that was **guessed** rather than given must also look like a
+project — it needs one of `.git`, `Cargo.toml`, `package.json`,
+`pyproject.toml`, `go.mod`, `composer.json`, and friends.
+
+The distinction matters:
+
+- **You named the path** (`neuromesh mcp <path>`, `NEUROMESH_WORKSPACE`, an MCP
+  client's `rootUri`) → safety checks only. Pointing at a nested folder with no
+  manifest is supported and keeps working.
+- **We inferred the path** (current directory, `neuromesh monitor`) → safety
+  checks *and* a project marker. Without this, a server started with no
+  workspace would index whatever happened to be in the current directory.
+
+A refusal prints what was wrong and how to fix it, rather than silently
+indexing.
+
+Ignore rules (`node_modules`, `target`, `dist`, `vendor`, …) apply to paths
+**relative to the workspace root**. A project that lives under a folder named
+`build` or `dist`, or on Windows under `AppData`, indexes normally — only its
+own subdirectories are matched.
+
+## Monorepos
+
+Today a monorepo is one project: one id, one graph. That is predictable and
+right for most repositories. Splitting a monorepo into independently-scoped
+sub-projects is a separate, explicit feature and is not implemented yet.
+
+The monitor's `__all__` endpoint deliberately indexes sibling projects into a
+single `collective_mesh` graph. That is an intentional cross-project view, not a
+leak: nodes take the graph's current id at ingest, so the invariant still holds.
+
+## Verifying it
+
+`cargo test -p neuromesh-context --test cross_project_isolation` is a CI-gated
+end-to-end check. It stages two fixtures — a Rust web service and a PyTorch
+detection project — that share `scripts/util.py` byte-for-byte, swaps between
+them, and asserts that the shared file changes owner, that no Rust file survives
+into the Python project, and that no Rust file reaches its packet.
+
+Unit coverage lives in `crates/neuromesh-graph/src/isolation_tests.rs` and
+`crates/neuromesh-core/src/project_id.rs`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -4,7 +4,7 @@ Transport: **stdio JSON-RPC** (`neuromesh mcp <workspace>`). **v0.9.0 default:**
 
 That is what Cursor, Claude, Codex, OpenCode, MiMo CLI, Antigravity, Kilo Code, Trae, Cline, and similar clients launch. Stdio has **no TCP port** — `--port` on `mcp` does nothing. Background index uses the same file-cap rules as `neuromesh index` (`--max-files`, `NEUROMESH_MAX_FILES`, project-slot `config.json`; default auto, ceiling 50,000). See [cli.md](cli.md#index-file-cap).
 
-**Warning:** Never run `neuromesh mcp` without a workspace path (or `NEUROMESH_WORKSPACE`) **unless** the IDE sets `WORKSPACE_FOLDER_PATHS` / `VSCODE_CWD` or sends a workspace root in MCP `initialize`. Without any of those, the server may bind to your home directory and index unrelated projects. For a one-time global install, use the simple config below; `neuromesh connect --global` writes it to `~/.cursor/mcp.json`.
+**Workspace binding:** running `neuromesh mcp` without a workspace path (or `NEUROMESH_WORKSPACE`) is safe — when the IDE sets neither `WORKSPACE_FOLDER_PATHS` / `VSCODE_CWD` nor a workspace root in MCP `initialize`, the server refuses to index rather than binding to your home directory, and says so on stderr. Passing a path is still the most predictable option. Each project is identified by its own path and gets its own graph and memory; see [isolation.md](isolation.md). For a one-time global install, use the simple config below; `neuromesh connect --global` writes it to `~/.cursor/mcp.json`.
 
 Remote / multi-agent: `neuromesh monitor` (optionally `--port 9000` / `neuromesh port 9000`), then SSE and HTTP as in [api.md](api.md).
 

--- a/tests/fixtures/iso-ml-python/dataset.py
+++ b/tests/fixtures/iso-ml-python/dataset.py
@@ -1,0 +1,32 @@
+"""Detection dataset and its preprocessing transforms."""
+
+
+class DetectionDataset:
+    """Reads image/annotation pairs and applies the configured transforms."""
+
+    def __init__(self, root, split="train", transforms=None):
+        self.root = root
+        self.split = split
+        self.transforms = transforms
+        self.samples = []
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, index):
+        image, target = self.samples[index]
+        if self.transforms is not None:
+            image, target = self.transforms(image, target)
+        return image, target
+
+
+def build_transforms(image_size=640, augment=True):
+    """Resize and, for training, augment. Changing this shifts mAP."""
+    steps = [("resize", image_size)]
+    if augment:
+        steps.append(("hflip", 0.5))
+    return steps
+
+
+def build_dataloader(dataset, batch_size=16, shuffle=True):
+    return {"dataset": dataset, "batch_size": batch_size, "shuffle": shuffle}

--- a/tests/fixtures/iso-ml-python/model.py
+++ b/tests/fixtures/iso-ml-python/model.py
@@ -1,0 +1,32 @@
+"""Detector backbone, head, and loss."""
+
+
+class Detector:
+    """Single-stage detector used by the training and evaluation loops."""
+
+    def __init__(self, num_classes=80, backbone="resnet50"):
+        self.num_classes = num_classes
+        self.backbone = backbone
+
+    def forward(self, images):
+        features = self.extract_features(images)
+        return self.predict_boxes(features)
+
+    def extract_features(self, images):
+        return {"backbone": self.backbone, "images": images}
+
+    def predict_boxes(self, features):
+        return [{"box": [0, 0, 1, 1], "score": 0.0} for _ in range(self.num_classes)]
+
+
+def detection_loss(predictions, targets):
+    """Classification plus box regression loss."""
+    return len(predictions) - len(targets)
+
+
+def load_checkpoint(path):
+    return {"path": path, "epoch": 0}
+
+
+def save_checkpoint(model, path, epoch):
+    return {"model": model.backbone, "path": path, "epoch": epoch}

--- a/tests/fixtures/iso-ml-python/scripts/util.py
+++ b/tests/fixtures/iso-ml-python/scripts/util.py
@@ -1,0 +1,20 @@
+"""Shared tooling helper.
+
+This file is intentionally byte-identical to the copy in the sibling isolation
+fixture. Two unrelated projects very often carry the same helper, config, or
+license file at the same relative path. `ingest_file_keep` returns early when a
+path's stored hash equals the incoming hash, so without a clean project swap
+the previous project's nodes for this path survive into the next project's
+graph. That is the leak `cross_project_isolation` guards against — do not edit
+one copy without editing the other.
+"""
+
+import os
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def read_env(name, default=None):
+    return os.environ.get(name, default)

--- a/tests/fixtures/iso-ml-python/train.py
+++ b/tests/fixtures/iso-ml-python/train.py
@@ -1,0 +1,31 @@
+"""Training entry point: dataset -> model -> loss -> checkpoint -> mAP."""
+
+from dataset import DetectionDataset, build_dataloader, build_transforms
+from model import Detector, detection_loss, save_checkpoint
+
+
+def train_one_epoch(model, dataloader, epoch):
+    total = 0.0
+    for batch in range(dataloader["batch_size"]):
+        predictions = model.forward(batch)
+        total += detection_loss(predictions, [])
+    return total
+
+
+def evaluate_map(model, dataloader):
+    """Mean average precision over the validation split."""
+    predictions = model.forward(dataloader)
+    return len(predictions) / 100.0
+
+
+def main():
+    transforms = build_transforms(image_size=640, augment=True)
+    dataset = DetectionDataset("data/coco", split="train", transforms=transforms)
+    dataloader = build_dataloader(dataset, batch_size=16)
+    model = Detector(num_classes=80)
+
+    for epoch in range(2):
+        train_one_epoch(model, dataloader, epoch)
+        save_checkpoint(model, "runs/last.pt", epoch)
+
+    return evaluate_map(model, dataloader)

--- a/tests/fixtures/iso-web-rust/scripts/util.py
+++ b/tests/fixtures/iso-web-rust/scripts/util.py
@@ -1,0 +1,20 @@
+"""Shared tooling helper.
+
+This file is intentionally byte-identical to the copy in the sibling isolation
+fixture. Two unrelated projects very often carry the same helper, config, or
+license file at the same relative path. `ingest_file_keep` returns early when a
+path's stored hash equals the incoming hash, so without a clean project swap
+the previous project's nodes for this path survive into the next project's
+graph. That is the leak `cross_project_isolation` guards against — do not edit
+one copy without editing the other.
+"""
+
+import os
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def read_env(name, default=None):
+    return os.environ.get(name, default)

--- a/tests/fixtures/iso-web-rust/src/handlers.rs
+++ b/tests/fixtures/iso-web-rust/src/handlers.rs
@@ -1,0 +1,14 @@
+/// Liveness probe used by the load balancer.
+pub fn health_handler() -> &'static str {
+    "ok"
+}
+
+/// Accept an order payload and hand it to the store.
+pub fn submit_order_handler(payload: &str) -> usize {
+    validate_order_payload(payload);
+    payload.len()
+}
+
+fn validate_order_payload(payload: &str) -> bool {
+    !payload.is_empty()
+}

--- a/tests/fixtures/iso-web-rust/src/main.rs
+++ b/tests/fixtures/iso-web-rust/src/main.rs
@@ -1,0 +1,10 @@
+mod handlers;
+mod router;
+
+use router::Router;
+
+fn main() {
+    let mut router = Router::new();
+    router.register_routes();
+    println!("serving {} routes", router.route_count());
+}

--- a/tests/fixtures/iso-web-rust/src/router.rs
+++ b/tests/fixtures/iso-web-rust/src/router.rs
@@ -1,0 +1,29 @@
+use crate::handlers::{health_handler, submit_order_handler};
+
+pub struct Router {
+    routes: Vec<(String, String)>,
+}
+
+impl Router {
+    pub fn new() -> Self {
+        Self { routes: Vec::new() }
+    }
+
+    /// Register every HTTP route this service exposes.
+    pub fn register_routes(&mut self) {
+        self.routes.push(("GET /health".into(), "health".into()));
+        self.routes.push(("POST /orders".into(), "orders".into()));
+        health_handler();
+        submit_order_handler("seed");
+    }
+
+    pub fn route_count(&self) -> usize {
+        self.routes.len()
+    }
+}
+
+impl Default for Router {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## What this fixes

Two projects opened in one MCP process can end up sharing a graph. Today isolation is *incidental* rather than enforced, and it breaks along three concrete paths:

1. **`ProjectId` is the workspace directory name.** `ProjectId::new(path.file_name())` in `mcp/server.rs` and `cli/main.rs` means two unrelated checkouts both called `app` / `api` / `backend` share one identity. Every "is this the same project?" comparison is then silently wrong, and `ContextNode::project_id` is useless as an isolation signal.

2. **A workspace switch can be skipped entirely.** `adopt_workspace_from_initialize` returns early when the incoming path equals the current root. With a directory-name id, that early-return can be reached for a genuinely different project, and the previous project's graph keeps being served.

3. **A shared path with identical bytes never gets re-ingested.** `ingest_file_keep` returns early when the stored hash for a relative path equals the incoming hash. Two projects very often share both a relative path *and* its exact contents — `LICENSE`, `.gitignore`, an empty `__init__.py`, boilerplate config. After a switch the new project's copy is never ingested and the old project's nodes for that path survive, still tagged with the old `project_id`. `prune_absent_files` cannot clean this up, because the path *is* present in the new project.

Two related bugs surfaced while testing this and are fixed in the same series:

4. **A project under a folder named `build` / `dist` / `vendor` / `target` / `node_modules` indexes to zero files.** `is_ignored` inspects every component of the absolute path it is handed, so directories *above* the workspace are inspected too. On Windows this hits anything under `AppData`, which is where `std::env::temp_dir()` points. Silent total failure that just looks like the tool not working.

5. **Memory writes land in the previous project.** `McpToolHandler` holds one `MemoryDatabase`, opened for the workspace the CLI started in. Swapping the graph left the store pinned, so episodes went into the previous project's `neuromesh.json` and the new project's own memory was invisible.

## How

- **`stable_project_id`** — a pure function of the canonical path of the project root (nearest enclosing `.git`, else the workspace itself), digested with the same sha256 + `normalize_workspace` pair the managed-store slot name already uses, so an id and its storage slot agree on project identity. No git binary needed; worktree/submodule `.git` files handled; nothing written into the user's repo.
- **A checked single-project invariant** — `foreign_nodes()` / `assert_single_project()` report, `evict_foreign_nodes()` heals (clearing `file_hashes` so the next scan re-ingests the path rather than skipping it again), `enforce_single_project()` runs after ingest in `reindex_incremental`.
- **A real hot-swap** — the early-return now requires the same stable id *and* the same root; a genuine switch calls `graph.clear(Some(pid))`. `reconcile_loaded_project_id` re-stamps a snapshot carrying one uniform stale id (an old directory-name graph) but deliberately leaves a snapshot carrying several ids for eviction rather than laundering it into looking clean.
- **`is_ignored_within(root, path)`** strips the workspace prefix before applying ignore rules.
- **Explicit vs guessed workspace** — `workspace_rejection_reason` (safety only, for a path the user named) and `discovered_workspace_rejection_reason` (safety plus a project marker, for a root we inferred). `explicit_workspace` still honours a nested folder with no manifest, so that supported case is unchanged.
- **The memory store follows the workspace**, renamed to `memory_store` and reached through `memory_db()` so no call site can keep the pinned value by accident.

## Proof

`crates/neuromesh-context/tests/cross_project_isolation.rs`, wired as its own CI step. Two fixtures — a Rust web service and a PyTorch project — share `scripts/util.py` byte-for-byte on purpose, which is exactly case 3. The test asserts the shared file changes owner across each swap, checks both the graph invariant and the emitted packet, and swaps back so the fix cannot be one-directional. Fixtures are staged outside any repository, since `stable_project_id` resolves to the nearest enclosing repo.

Full suite green locally on Windows (`cargo fmt --all` / `cargo clippy --all-targets` / `cargo test --all`).

## Notes / non-goals

- **Monorepos stay one project.** `stable_project_id` walks up to the nearest `.git`. Splitting a monorepo into sub-projects is a separate, explicit feature and is not attempted here.
- **The monitor's `__all__` endpoint is left alone.** Indexing sibling projects into one `collective_mesh` graph is deliberate, and since nodes take the graph's current id at ingest, the invariant still holds for it.
- The commits are self-contained and readable in order; happy to squash, split, or drop `docs/isolation.md` if you'd rather document it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
